### PR TITLE
Switch to using the snapcraft snap over the deb

### DIFF
--- a/git-ubuntu/jobs-ci.yaml
+++ b/git-ubuntu/jobs-ci.yaml
@@ -77,7 +77,7 @@
                 steps {{
                     deleteDir()
                     git url: 'https://github.com/CanonicalLtd/server-test-scripts', branch: 'master'
-                    sh 'http_proxy="http://squid.internal:3128" https_proxy="http://squid.internal:3128" ./git-ubuntu/vm_setup "$VM_NAME"'
+                    sh 'http_proxy="http://squid.internal:3128" https_proxy="http://squid.internal:3128" ./git-ubuntu/vm_setup "$VM_NAME" --snapcraft-snap'
                 }}
             }}
 
@@ -153,7 +153,7 @@
                 steps {{
                     deleteDir()
                     git url: 'https://github.com/CanonicalLtd/server-test-scripts', branch: 'master'
-                    sh 'http_proxy="http://squid.internal:3128" https_proxy="http://squid.internal:3128" ./git-ubuntu/vm_setup "$VM_NAME"'
+                    sh 'http_proxy="http://squid.internal:3128" https_proxy="http://squid.internal:3128" ./git-ubuntu/vm_setup "$VM_NAME" --snapcraft-snap'
                 }}
             }}
 


### PR DESCRIPTION
The two sources for snapcraft differ on behaviour and release
management. We're having trouble aligning our CI with "official" builds
on Launchpad. We've been advised to try the edge snap which has some
non-determinism removed. And we're told that Launchpad is expected to
switch to the snap eventually. So tweak our CI accordingly.