### PR TITLE
simplestreams: Move to using git and run tox in a container.

### DIFF
--- a/simplestreams/jobs.yaml
+++ b/simplestreams/jobs.yaml
@@ -54,12 +54,16 @@
           #!/bin/bash -x
           export https_proxy=http://squid.internal:3128
           export no_proxy=launchpad.net
-
           rm -rf *
-          git clone https://git.launchpad.net/simplestreams -b ${branch} debug
-          cd debug
 
-          tox ${tox_parameters}
+          git clone https://github.com/CanonicalLtd/uss-tableflip.git uss-tableflip
+          PATH=$PWD/uss-tableflip/scripts:$PATH
+
+          ctool run-container -v --destroy "--name=ssdebug-$BUILD_NUMBER" \
+              ubuntu-daily:bionic \
+              --git="${branch}" \
+              -- sh -c './tools/install-deps tox && tox "$@"' \
+                 -- ${tox_parameters}
 
 - job:
     name: simplestreams-tests
@@ -86,8 +90,15 @@
           #!/bin/bash -x
           export https_proxy=http://squid.internal:3128
           export no_proxy=launchpad.net
+          branch=https://git.launchpad.net/simplestreams
+          tox_parameters=""
 
           rm -rf *
-          git clone https://git.launchpad.net/simplestreams tests-$BUILD_NUMBER
-          cd tests-$BUILD_NUMBER
-          tox
+
+          git clone https://github.com/CanonicalLtd/uss-tableflip.git uss-tableflip
+          PATH=$PWD/uss-tableflip/scripts:$PATH
+
+          ctool run-container -v --destroy "--name=sstest-$BUILD_NUMBER" \
+              ubuntu-daily:bionic \
+              --git="${branch}" \
+              -- sh -c './tools/install-deps tox && tox "$@"' -- ${tox_parameters}

--- a/simplestreams/parameters.yaml
+++ b/simplestreams/parameters.yaml
@@ -49,8 +49,8 @@
     parameters:
       - string:
           name: branch
-          default: lp:simplestreams
-          description: LaunchPad branch to use for running the test.
+          default: https://git.launchpad.net/simplestreams
+          description: git url to clone (e.g. 'https://git.launchpad.net/simplestreams[@COMMITISH]')
 
 - parameter:
     name: tox-parameters


### PR DESCRIPTION
Simplestreams has moved from bzr to git, and bzr will stop working
shortly. [1]

It also changes the tests to run in an lxc (bionic) container via
utilization of 'ctool' which was added today to uss-tableflip.

Hopefully running in a container will fix the errors we've been
seeing lately around gpg:
  gpg: can't connect to the agent: IPC connect call failed
  gpg: error getting the KEK: No agent running

[1] https://code.launchpad.net/~smoser/simplestreams/trunk.moved-to-git/+merge/348547