### PR TITLE
simplestreams: use ctool for c-i review.

### DIFF
--- a/simplestreams/jobs-ci.yaml
+++ b/simplestreams/jobs-ci.yaml
@@ -73,12 +73,13 @@
           set -eux
           export https_proxy=http://squid.internal:3128
           export no_proxy=launchpad.net
-
           rm -rf *
-          git clone ${landing_candidate} ss-${BUILD_NUMBER}
-          cd ss-${BUILD_NUMBER}
-          git rev-parse HEAD
-          git remote add upstream https://git.launchpad.net/simplestreams
-          git fetch upstream --tags
 
-          tox
+          git clone https://github.com/CanonicalLtd/uss-tableflip.git uss-tableflip
+          PATH=$PWD/uss-tableflip/scripts:$PATH
+
+          ctool run-container -v --destroy "--name=${JOB_NAME}-$BUILD_NUMBER" \
+              ubuntu-daily:bionic \
+              --git="{landing_candidate}@{candidate_revision}" \
+              -- sh -c './tools/install-deps tox && tox "$@"' \
+                 -- ${tox_parameters}


### PR DESCRIPTION
This just makes the simplestreams c-i review tool use ctool as
we had done with the trunk tests.  We need to do that for the same reason
as the previous... to avoid gpg agent issues
 gpg: can't connect to the agent: IPC connect call failed