### PR TITLE
curtin: temporarily enable keep_data_fail and tar

### DIFF
--- a/curtin/jobs-vmtest-daily.yaml
+++ b/curtin/jobs-vmtest-daily.yaml
@@ -64,7 +64,9 @@
           export TMPDIR=/var/lib/jenkins/tmp/
           export CURTIN_VMTEST_CURTIN_EXE="curtin-from-container $LXC_NAME curtin"
           export CURTIN_VMTEST_SKIP_BY_DATE_BUGS="*"
-
+          export CURTIN_VMTEST_KEEP_DATA_FAIL=all
+          export CURTIN_VMTEST_TAR_DISKS=1
+          
           rm -Rf curtin-* output
           git clone --branch=master https://git.launchpad.net/curtin curtin-$BUILD_NUMBER
           cd curtin-$BUILD_NUMBER


### PR DESCRIPTION
These options will enable the taring up of disks and keeping them around when a specific test fails. This was requested by @raharper for a temporary test.