### PR TITLE
curtin: temporarily enable keep_data_fail

### DIFF
--- a/curtin/jobs-vmtest.yaml
+++ b/curtin/jobs-vmtest.yaml
@@ -147,6 +147,7 @@
                 export CURTIN_VMTEST_ADD_REPOS=${vmtest_add_repos}
             fi
 
+            export CURTIN_VMTEST_KEEP_DATA_FAIL=all
             export CURTIN_VMTEST_TAR_DISKS=1
 
             rm -Rf curtin-*


### PR DESCRIPTION
Enable keeping of disks when a specific test fails. This was requested by @raharper for a temporary test.