### PR TITLE
Switching metrics/cloud_images to InfluxDB

### DIFF
--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -57,8 +57,10 @@
 - job:
     name: metric-foundations-cloud-images
     builders:
-      - simple-metric:
+      - metric-influxdb:
+          team: "foundations"
           metric_module: "cloud_images"
+          metric_arguments: ""
 
 - job:
     name: metric-foundations-docker-hub-images


### PR DESCRIPTION
This depends on https://github.com/CanonicalLtd/metrics/pull/7