### PR TITLE
chmod non-writable dirs in vmtest output dir

### DIFF
--- a/curtin/jobs-vmtest-daily.yaml
+++ b/curtin/jobs-vmtest-daily.yaml
@@ -63,6 +63,8 @@
           export CURTIN_VMTEST_CURTIN_EXE="curtin-from-container $LXC_NAME curtin"
           export CURTIN_VMTEST_SKIP_BY_DATE_BUGS="*"
 
+          # ensure directories are writable for non-root delete
+          find output -perm 0550  | xargs -i chmod -R +w {}
           rm -Rf curtin-* output
           git clone --branch=master https://git.launchpad.net/curtin curtin-$BUILD_NUMBER
           cd curtin-$BUILD_NUMBER

--- a/curtin/jobs-vmtest-proposed.yaml
+++ b/curtin/jobs-vmtest-proposed.yaml
@@ -99,6 +99,8 @@
           export CURTIN_VMTEST_TAR_DISKS=1
           export CURTIN_VMTEST_SKIP_BY_DATE_BUGS="*"
 
+          # ensure directories are writable for non-root delete
+          find . -perm 0550  | xargs -i chmod -R +w {}
           rm -Rf curtin-* output
           pull-lp-source curtin "$RELEASE"-proposed
           cd curtin-*

--- a/curtin/jobs-vmtest.yaml
+++ b/curtin/jobs-vmtest.yaml
@@ -140,12 +140,13 @@
             if [ -n "${vmtest_add_repos}" ]; then
                 export CURTIN_VMTEST_ADD_REPOS=${vmtest_add_repos}
             fi
-            
+
             export CURTIN_VMTEST_KEEP_DATA_FAIL=all
             export CURTIN_VMTEST_TAR_DISKS=1
-            
-            rm -Rf curtin-*
-            rm -Rf output
+
+            # ensure directories are writable for non-root delete
+            find output -perm 0550  | xargs -i chmod -R +w {}
+            rm -Rf curtin-* output
             git clone --branch=${landing_candidate_branch} ${landing_candidate} curtin-${BUILD_NUMBER}
             cd curtin-${BUILD_NUMBER}
             git remote add upstream https://git.launchpad.net/curtin

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -49,6 +49,8 @@
           rm -rf *
           git clone https://github.com/CanonicalLtd/metrics.git
           cd metrics
+          bzr branch lp:kpi-metrics-tools
+          source kpi-metrics-tools/foundations-kpi-influxdb.txt
           export METRICS_PROMETHEUS=10.25.2.225:9091
           python3 -m metrics.foundations_autopkgtest_queue --queues {queue_name}
 


### PR DESCRIPTION
Centos vmtests sometimes leave a root dir with non-writable
permissions which prevents the rm -Rf from cleaning up.