### PR TITLE
torkoal: set TMPDIR in cloud-init nocloud-kvm tests to use nvme drive.

### DIFF
--- a/cloud-init/integration-nocloudkvm.yaml
+++ b/cloud-init/integration-nocloudkvm.yaml
@@ -64,6 +64,9 @@
           git clone https://git.launchpad.net/cloud-init
           cd cloud-init
           ../server-test-scripts/cloud-init/daily_deb.sh -v $release
+          if [ -z "$TMPDIR" -a "$(hostname)" = "torkoal" ]; then
+              export TMPDIR=/var/lib/jenkins/tmp/
+          fi
           no_proxy=launchpad.net https_proxy="http://squid.internal:3128" tox \
             -e citest -- run --os-name $release \
             --platform nocloud-kvm --preserve-data --data-dir results \

--- a/cloud-init/integration-proposed.yaml
+++ b/cloud-init/integration-proposed.yaml
@@ -98,6 +98,9 @@
           echo "Running with source from tag $tag"
           git checkout $tag
           mirror="http://archive.ubuntu.com/ubuntu/"
+          if [ -z "$TMPDIR" -a "$(hostname)" = "torkoal" ]; then
+              export TMPDIR=/var/lib/jenkins/tmp/
+          fi
           set +e
           no_proxy=launchpad.net https_proxy="http://squid.internal:3128" tox \
               -e citest -- run \


### PR DESCRIPTION
The jenkins slave 'torkoal' has a tmpdir set up on top of an nvme disk at
/var/lib/jenkins/tmp.  This change will make the nocloud tests use
that for their TMPDIR.  The hope is that this will fix some timeouts
we were seeing in nocloud-kvm tests where the system simply was taking
longer than allowed to boot.

Note that TMPDIR is documented (and tested locally) as passing
through tox without a 'passenv'.