### PR TITLE
cloud-init: Match test harness version and daily deb version.

### DIFF
--- a/cloud-init/integration-ec2.yaml
+++ b/cloud-init/integration-ec2.yaml
@@ -64,17 +64,28 @@
     name: integration-ec2
     builders:
       - shell: |
+          set -e
           release="{release}"
 
           sudo rm -Rf *
           git clone https://github.com/CanonicalLtd/server-test-scripts.git
+          ./server-test-scripts/cloud-init/daily_deb.sh -v $release
+          deb=$(echo "$PWD/cloud-init_"*.deb)
+          if [ ! -f "$deb" ]; then
+              echo "Failed to get deb? [$deb]";
+              exit 1;
+          fi
+          # extract hash from cloud-init...-g[a-f][a-f]..._all.deb
+          hash=$(echo "$deb" | sed 's,.*-g\([0-9a-f]\+\)-.*,\1,')
+          echo "deb=$(basename $deb) hash=$hash"
           git clone https://git.launchpad.net/cloud-init
           cd cloud-init
-          ../server-test-scripts/cloud-init/daily_deb.sh -v $release
+          git checkout --quiet "$hash"
+          git log --max-count=1 --pretty=oneline HEAD
           no_proxy=launchpad.net https_proxy="http://squid.internal:3128" tox \
-            -e citest -- run --os-name $release \
-            --platform ec2 --preserve-data --data-dir results \
-            --verbose --deb cloud-init_*_all.deb
+            -e citest -- run "--os-name=$release" \
+            --platform=ec2 --preserve-data --data-dir=results \
+            --verbose "--deb=$deb"
 
 - job:
     name: cloud-init-integration-ec2-terminate

--- a/cloud-init/integration-lxd.yaml
+++ b/cloud-init/integration-lxd.yaml
@@ -57,14 +57,25 @@
     name: integration-lxd
     builders:
       - shell: |
+          set -e
           release="{release}"
 
           sudo rm -Rf *
           git clone https://github.com/CanonicalLtd/server-test-scripts.git
+          ./server-test-scripts/cloud-init/daily_deb.sh -v $release
+          deb=$(echo "$PWD/cloud-init_"*.deb)
+          if [ ! -f "$deb" ]; then
+              echo "Failed to get deb? [$deb]";
+              exit 1;
+          fi
+          # extract hash from cloud-init...-g[a-f][a-f]..._all.deb
+          hash=$(echo "$deb" | sed 's,.*-g\([0-9a-f]\+\)-.*,\1,')
+          echo "deb=$(basename $deb) hash=$hash"
           git clone https://git.launchpad.net/cloud-init
           cd cloud-init
-          ../server-test-scripts/cloud-init/daily_deb.sh -v $release
+          git checkout --quiet "$hash"
+          git log --max-count=1 --pretty=oneline HEAD
           no_proxy=launchpad.net https_proxy="http://squid.internal:3128" tox \
-            -e citest -- run --os-name $release \
-            --platform lxd --preserve-data --data-dir results \
-            --verbose --deb cloud-init_*_all.deb
+            -e citest -- run "--os-name=$release" \
+            --platform=lxd --preserve-data --data-dir=results \
+            --verbose "--deb=$deb"

--- a/cloud-init/integration-nocloudkvm.yaml
+++ b/cloud-init/integration-nocloudkvm.yaml
@@ -58,16 +58,25 @@
     builders:
       - shell: |
           release="{release}"
-
-          sudo rm -Rf *
-          git clone https://github.com/CanonicalLtd/server-test-scripts.git
-          git clone https://git.launchpad.net/cloud-init
-          cd cloud-init
-          ../server-test-scripts/cloud-init/daily_deb.sh -v $release
           if [ -z "$TMPDIR" -a "$(hostname)" = "torkoal" ]; then
               export TMPDIR=/var/lib/jenkins/tmp/
           fi
+          sudo rm -Rf *
+          git clone https://github.com/CanonicalLtd/server-test-scripts.git
+          ./server-test-scripts/cloud-init/daily_deb.sh -v $release
+          deb=$(echo "$PWD/cloud-init_"*.deb)
+          if [ ! -f "$deb" ]; then
+              echo "Failed to get deb? [$deb]";
+              exit 1;
+          fi
+          # extract hash from cloud-init...-g[a-f][a-f]..._all.deb
+          hash=$(echo "$deb" | sed 's,.*-g\([0-9a-f]\+\)-.*,\1,')
+          echo "deb=$(basename $deb) hash=$hash"
+          git clone https://git.launchpad.net/cloud-init
+          cd cloud-init
+          git checkout --quiet "$hash"
+          git log --max-count=1 --pretty=oneline HEAD
           no_proxy=launchpad.net https_proxy="http://squid.internal:3128" tox \
-            -e citest -- run --os-name $release \
-            --platform nocloud-kvm --preserve-data --data-dir results \
-            --verbose --deb cloud-init_*_all.deb
+            -e citest -- run "--os-name=$release" \
+            --platform=nocloud-kvm --preserve-data --data-dir=results \
+            --verbose "--deb=$deb"


### PR DESCRIPTION
When running integration tests, we should match the version of the
test-harness with the version of the deb we're running.  Otherwise
we will get skew and have test failures when a test makes an assertion
that is not availble in the installed package or vice-versa.

The fix here pulls the hash out of the daily deb file name.
   cloud-init_18.4-1964-g9f88125-0ubuntu1+1635~trunk~ubuntu18.04.1_all.deb

It grabs the -g9f88125 there and then checks out cloud-init at gf88125.