### PR TITLE
curtin: Add a vmtest_filters parameter for proposed testing default to ubuntu only

### DIFF
--- a/curtin/jobs-vmtest.yaml
+++ b/curtin/jobs-vmtest.yaml
@@ -149,10 +149,10 @@
             if [ -n "${vmtest_filters}" ]; then
                 f=""
                 for f in ${vmtest_filters}; do
-                    filter_args="${filter_args} --filter ${f}"
+                    filter_args="$filter_args --filter=$f"
                 done
             fi
-            echo "test filter args: \"${filter_args}\""
+            echo "test filter args: \"$filter_args\""
 
             # Helpful in debugging, but fill up Jenkins if all test fail
             # export CURTIN_VMTEST_KEEP_DATA_FAIL=all
@@ -167,7 +167,7 @@
 
             ./tools/vmtest-system-setup
             set +e
-            ./tools/jenkins-runner -p4 ${filter_args} ${nose_args}
+            ./tools/jenkins-runner -p4 $filter_args ${nose_args}
             RET=$?
 
             cd ${WORKSPACE}

--- a/curtin/jobs-vmtest.yaml
+++ b/curtin/jobs-vmtest.yaml
@@ -121,6 +121,9 @@
         - string:
             name: vmtest_add_repos
             default: "proposed"
+        - string:
+            name: vmtest_filters
+            default: "target_distro=ubuntu"
     properties:
       - build-discarder:
           num-to-keep: 5
@@ -141,6 +144,16 @@
                 export CURTIN_VMTEST_ADD_REPOS=${vmtest_add_repos}
             fi
 
+            # construct vmtest filters
+            filter_args=""
+            if [ -n "${vmtest_filters}" ]; then
+                f=""
+                for f in ${vmtest_filters}; do
+                    filter_args="${filter_args} --filter ${f}"
+                done
+            fi
+            echo "test filter args: \"${filter_args}\""
+
             # Helpful in debugging, but fill up Jenkins if all test fail
             # export CURTIN_VMTEST_KEEP_DATA_FAIL=all
             # export CURTIN_VMTEST_TAR_DISKS=1
@@ -155,7 +168,7 @@
             ./tools/vmtest-system-setup
             set +e
             # Only run -proposed on Ubuntu
-            ./tools/jenkins-runner -p4 --filter target_distro=ubuntu ${nose_args}
+            ./tools/jenkins-runner -p4 ${filter_args} ${nose_args}
             RET=$?
 
             cd ${WORKSPACE}

--- a/curtin/jobs-vmtest.yaml
+++ b/curtin/jobs-vmtest.yaml
@@ -140,11 +140,11 @@
             if [ -n "${vmtest_add_repos}" ]; then
                 export CURTIN_VMTEST_ADD_REPOS=${vmtest_add_repos}
             fi
-            
+
             # Helpful in debugging, but fill up Jenkins if all test fail
             # export CURTIN_VMTEST_KEEP_DATA_FAIL=all
             # export CURTIN_VMTEST_TAR_DISKS=1
-            
+
             rm -Rf curtin-*
             rm -Rf output
             git clone --branch=${landing_candidate_branch} ${landing_candidate} curtin-${BUILD_NUMBER}
@@ -154,7 +154,8 @@
 
             ./tools/vmtest-system-setup
             set +e
-            ./tools/jenkins-runner -p4 ${nose_args}
+            # Only run -proposed on Ubuntu
+            ./tools/jenkins-runner -p4 --filter target_distro=ubuntu ${nose_args}
             RET=$?
 
             cd ${WORKSPACE}

--- a/curtin/jobs-vmtest.yaml
+++ b/curtin/jobs-vmtest.yaml
@@ -167,7 +167,6 @@
 
             ./tools/vmtest-system-setup
             set +e
-            # Only run -proposed on Ubuntu
             ./tools/jenkins-runner -p4 ${filter_args} ${nose_args}
             RET=$?
 


### PR DESCRIPTION
We want to only test ubuntu for our proposed testing.  Add a new
parameter to the proposed test and set the default value to
target_distro=ubuntu.  This allows users to customize the job
later so add additional (or remove) the filter as well.