### PR TITLE
simplestreams-build: invoke build-deb -S also with -d (ignore depends).

### DIFF
--- a/simplestreams/jobs.yaml
+++ b/simplestreams/jobs.yaml
@@ -21,12 +21,15 @@
     builders:
       - shell: |
           #!/bin/bash -x
+          set -e
+          release=xenial
+
           rm -rf *
           git clone https://git.launchpad.net/simplestreams build
           cd build
 
-          ./tools/build-deb -S -us -uc
-          sbuild --nolog --verbose --dist=xenial simplestreams_*.dsc
+          ./tools/build-deb -d -S -us -uc
+          sbuild --nolog --verbose "--dist=$release" simplestreams_*.dsc
 
 - job:
     name: simplestreams-debug


### PR DESCRIPTION
When building source, we dont need all the depends.
Also run with 'set -e' so that if the bddeb fails we do not go on
and try to sbuild with a non-existing file *.dsc.