### PR TITLE
cloud-init: add disco jobs

### DIFF
--- a/cloud-init/default.yaml
+++ b/cloud-init/default.yaml
@@ -29,13 +29,16 @@
       - cloud-init-github-mirror
       - cloud-init-integration-ec2-b
       - cloud-init-integration-ec2-c
+      - cloud-init-integration-ec2-d
       - cloud-init-integration-ec2-x
       - cloud-init-integration-ec2-terminate
       - cloud-init-integration-lxd-b
       - cloud-init-integration-lxd-c
+      - cloud-init-integration-lxd-d
       - cloud-init-integration-lxd-x
       - cloud-init-integration-nocloud-kvm-b
       - cloud-init-integration-nocloud-kvm-c
+      - cloud-init-integration-nocloud-kvm-d
       - cloud-init-integration-nocloud-kvm-x
       - cloud-init-integration-proposed-b
       - cloud-init-integration-proposed-c

--- a/cloud-init/integration-ec2.yaml
+++ b/cloud-init/integration-ec2.yaml
@@ -60,6 +60,21 @@
       - integration-ec2:
           release: cosmic
 
+- job:
+    name: cloud-init-integration-ec2-d
+    node: torkoal
+    triggers:
+      - timed: "H 0 * * 4"
+    publishers:
+      - email-server-crew
+      - archive-results
+      - trigger:
+          project: cloud-init-integration-ec2-terminate
+          threshold: FAILURE
+    builders:
+      - integration-ec2:
+          release: disco
+
 - builder:
     name: integration-ec2
     builders:

--- a/cloud-init/integration-lxd.yaml
+++ b/cloud-init/integration-lxd.yaml
@@ -53,6 +53,16 @@
       - integration-lxd:
           release: cosmic
 
+- job:
+    name: cloud-init-integration-lxd-d
+    node: torkoal
+    publishers:
+      - email-server-crew
+      - archive-results
+    builders:
+      - integration-lxd:
+          release: disco
+
 - builder:
     name: integration-lxd
     builders:

--- a/cloud-init/integration-nocloudkvm.yaml
+++ b/cloud-init/integration-nocloudkvm.yaml
@@ -53,6 +53,16 @@
       - integration-nocloud-kvm:
           release: cosmic
 
+- job:
+    name: cloud-init-integration-nocloud-kvm-d
+    node: torkoal
+    publishers:
+      - email-server-crew
+      - archive-results
+    builders:
+      - integration-nocloud-kvm:
+          release: disco
+
 - builder:
     name: integration-nocloud-kvm
     builders:


### PR DESCRIPTION
This adds the integration test jobs for EC2, LXD, and KVM.