### PR TITLE
cloud-init: set http_proxy and https_proxy before calling run-centos

### DIFF
--- a/cloud-init/centos.yaml
+++ b/cloud-init/centos.yaml
@@ -35,7 +35,11 @@
           git clone https://github.com/CanonicalLtd/server-test-scripts
           git clone https://git.launchpad.net/cloud-init
           cd cloud-init
+
           export PYVER=python2
+          export http_proxy="http://squid.internal:3128"
+          export https_proxy="$http_proxy"
+
           ./tools/run-centos 7 --srpm --artifact
 
           cd "$WORKSPACE"


### PR DESCRIPTION
Another step towards fixing `cloud-init-copr-build`.