### PR TITLE
Remove the metric-server-google-analytics job

### DIFF
--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -261,30 +261,6 @@
           metric_arguments: "server"
 
 - job:
-    name: metric-server-google-analytics
-    builders:
-      - shell: |
-          #!/bin/bash
-          set -e
-          rm -rf *
-          git clone https://github.com/CanonicalLtd/metrics.git
-          cd metrics
-          export METRICS_PROMETHEUS=10.25.2.225:9091
-          python -m metrics.google_analytics
-    parameters:
-      - string:
-          name: HTTPS_PROXY
-          default: https://squid.internal:3128
-    wrappers:
-     - credentials-binding:
-         - file:
-            credential-id: ga-json-credentials
-            variable: GA_KEY_FILE_LOCATION
-         - text:
-            credential-id: ga-view-id
-            variable: GA_VIEW_ID
-
-- job:
     name: metric-openstack-uploads
     builders:
       - metric-influxdb:


### PR DESCRIPTION
Setup long ago at an attempt to collect metrics from it, but not doing
anything useful.