### PR TITLE
cloud-init: disable concurrent autoland builds

### DIFF
--- a/cloud-init/jobs-ci.yaml
+++ b/cloud-init/jobs-ci.yaml
@@ -195,6 +195,7 @@
     dsl: |
       pipeline {
         agent { label 'torkoal' }
+        options { disableConcurrentBuilds() }
         parameters {
             string (
                 defaultValue: 'lp:cloud-init',


### PR DESCRIPTION
In a case where change A and B cause each other to fail, but neither are
failing in isolation, running the autolander for A and B in parallel
will cause master to be broken after both complete.

(Per https://stackoverflow.com/a/48768101, this is how to disable
concurrent pipeline jobs.)