### PR TITLE
Disable staging retracer results, add in production retracer avg time

### DIFF
--- a/metrics/default.yaml
+++ b/metrics/default.yaml
@@ -30,7 +30,7 @@
       - metric-foundations-uploads
       - metric-foundations-merges
       - metric-foundations-retracers-results-production
-      - metric-foundations-retracers-results-staging
+      - metric-foundations-retracers-avg-time-production
       - metric-openstack-merges
       - metric-openstack-uploads
       - metric-rls-bug-tasks

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -293,9 +293,9 @@
           metric_arguments: "--environment production"
 
 - job:
-    name: metric-foundations-retracers-results-staging
+    name: metric-foundations-retracers-avg-time-production
     builders:
       - metric-influxdb:
           team: "foundations"
-          metric_module: "foundations_retracers_results"
-          metric_arguments: "--environment staging"
+          metric_module: "foundations_retracers_avg_time"
+          metric_arguments: "--environment production"


### PR DESCRIPTION
Staging isn't retracing crashes regularly so the retracer results job was failing regularly because there was no data. Subsequently, we'll drop that job for now.

I've also added in a job for the retracers average processing time metric.