### PR TITLE
add timeout to cloud-init,curtin,simplestreams trigger jobs

### DIFF
--- a/cloud-init/jobs-ci.yaml
+++ b/cloud-init/jobs-ci.yaml
@@ -20,6 +20,10 @@
     node: metal-amd64
     triggers:
         - timed: H/15 * * * *
+    wrappers:
+        # We run every 15 minutes, and runs usually take ~7 minutes
+        - timeout:
+            timeout: 15
     builders:
         - shell: |
             #!/bin/bash -x
@@ -36,6 +40,10 @@
     node: metal-amd64
     triggers:
         - timed: H/15 * * * *
+    wrappers:
+        # We run every 15 minutes, and runs usually take ~30 seconds
+        - timeout:
+            timeout: 15
     builders:
         - shell: |
             #!/bin/bash

--- a/curtin/jobs-ci.yaml
+++ b/curtin/jobs-ci.yaml
@@ -19,6 +19,10 @@
     name: curtin-ci-trigger
     triggers:
         - timed: H/15 * * * *
+    wrappers:
+        # We run every 15 minutes, and runs usually take a few seconds
+        - timeout:
+            timeout: 15
     builders:
         - shell: |
             #!/bin/bash -x
@@ -35,6 +39,10 @@
     node: metal-amd64
     triggers:
         - timed: H/15 * * * *
+    wrappers:
+        # We run every 15 minutes, and runs usually take a few seconds
+        - timeout:
+            timeout: 15
     builders:
         - shell: |
             #!/bin/bash

--- a/simplestreams/jobs-ci.yaml
+++ b/simplestreams/jobs-ci.yaml
@@ -19,6 +19,10 @@
     name: simplestreams-ci-trigger
     triggers:
       - timed: H/15 * * * *
+    wrappers:
+        # We run every 15 minutes, and runs usually take a few seconds
+        - timeout:
+            timeout: 15
     builders:
       - shell: |
           #!/bin/bash -x
@@ -36,6 +40,10 @@
     node: metal-amd64
     triggers:
         - timed: H/15 * * * *
+    wrappers:
+        # We run every 15 minutes, and runs usually take a few seconds
+        - timeout:
+            timeout: 15
     builders:
         - shell: |
             #!/bin/bash


### PR DESCRIPTION
These run in a predictable amount of time, so if they're taking more
than 15 minutes then we've almost certainly hit some sort of issue.