### PR TITLE
curtin: reschedule vmtests add disco

### DIFF
--- a/curtin/default.yaml
+++ b/curtin/default.yaml
@@ -43,7 +43,6 @@
       - curtin-vmtest-proposed-d
       - curtin-vmtest-proposed-d-trigger
       - curtin-vmtest-proposed-x
-      - curtin-vmtest-proposed-x
       - curtin-vmtest-proposed-x-trigger
 
 

--- a/curtin/default.yaml
+++ b/curtin/default.yaml
@@ -34,12 +34,15 @@
       - curtin-vmtest-devel-ppc64el
       - curtin-vmtest-devel-s390x
       - curtin-vmtest-sync-images
-      - curtin-vmtest-daily-t
       - curtin-vmtest-daily-x
+      - curtin-vmtest-daily-b
       - curtin-vmtest-proposed-b
       - curtin-vmtest-proposed-b-trigger
       - curtin-vmtest-proposed-c
       - curtin-vmtest-proposed-c-trigger
+      - curtin-vmtest-proposed-d
+      - curtin-vmtest-proposed-d-trigger
+      - curtin-vmtest-proposed-x
       - curtin-vmtest-proposed-x
       - curtin-vmtest-proposed-x-trigger
 

--- a/curtin/jobs-vmtest-daily.yaml
+++ b/curtin/jobs-vmtest-daily.yaml
@@ -16,30 +16,12 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 
 - job:
-    name: curtin-vmtest-daily-t
-    node: torkoal
-    parameters:
-        - nose-args
-    triggers:
-        - timed: "H 4 * * *"
-    properties:
-      - build-discarder:
-          num-to-keep: 5
-    publishers:
-        - email-server-crew
-        - archive-results
-    builders:
-      - vmtest-daily:
-          release: trusty
-          nose_args: nose_args
-
-- job:
     name: curtin-vmtest-daily-x
     node: torkoal
     parameters:
         - nose-args
     triggers:
-        - timed: "H 8 * * *"
+        - timed: "H 4 * * 1,3,5"
     properties:
       - build-discarder:
           num-to-keep: 5
@@ -50,6 +32,25 @@
       - vmtest-daily:
           release: xenial
           nose_args: nose_args
+
+- job:
+    name: curtin-vmtest-daily-b
+    node: torkoal
+    parameters:
+        - nose-args
+    triggers:
+        - timed: "H 4 * * 2,4,6"
+    properties:
+      - build-discarder:
+          num-to-keep: 5
+    publishers:
+        - email-server-crew
+        - archive-results
+    builders:
+      - vmtest-daily:
+          release: bionic
+          nose_args: nose_args
+
 
 - builder:
     name: vmtest-daily

--- a/curtin/jobs-vmtest-proposed.yaml
+++ b/curtin/jobs-vmtest-proposed.yaml
@@ -20,7 +20,7 @@
     name: curtin-vmtest-proposed-x-trigger
     node: torkoal
     triggers:
-      - timed: "H 14 * * *"
+      - timed: "H 10 * * 1,4"
     publishers:
         - email-server-crew
     builders:
@@ -32,7 +32,7 @@
     name: curtin-vmtest-proposed-b-trigger
     node: torkoal
     triggers:
-      - timed: "H 22 * * *"
+      - timed: "H 10 * * 2,5"
     publishers:
         - email-server-crew
     builders:
@@ -44,13 +44,25 @@
     name: curtin-vmtest-proposed-c-trigger
     node: torkoal
     triggers:
-      - timed: "H 06 * * *"
+      - timed: "H 10 * * 6"
     publishers:
         - email-server-crew
     builders:
       - vmtest-proposed-trigger:
           release: cosmic
           triggerwhat: curtin-vmtest-proposed-c
+
+- job:
+    name: curtin-vmtest-proposed-d-trigger
+    node: torkoal
+    triggers:
+      - timed: "H 10 * * 3,7"
+    publishers:
+        - email-server-crew
+    builders:
+      - vmtest-proposed-trigger:
+          release: disco
+          triggerwhat: curtin-vmtest-proposed-d
 
 
 - builder:
@@ -112,6 +124,19 @@
       - vmtest-proposed:
           release: cosmic
 
+- job:
+    name: curtin-vmtest-proposed-d
+    node: torkoal
+    auth-token: BUILD_ME
+    properties:
+      - build-discarder:
+          num-to-keep: 5
+    publishers:
+        - email-server-crew
+        - archive-results
+    builders:
+      - vmtest-proposed:
+          release: disco
 
 - builder:
     name: vmtest-proposed

--- a/curtin/jobs-vmtest.yaml
+++ b/curtin/jobs-vmtest.yaml
@@ -110,7 +110,7 @@
     name: curtin-vmtest-devel-amd64-proposed
     node: torkoal
     triggers:
-        - timed: "H 4 * * 7"
+        - timed: "H 8 * * 7"
     parameters:
         - landing-candidate
         - landing-candidate-branch


### PR DESCRIPTION
Curtin vmtest load is high and current runs take about 14 hours.
This branch does:

- Add disco to daily and -proposed
- Daily drops trusty, adds bionic, reschedules to 4 UTC, xenial
  on days 1,3,5, and bionic on days 2, 4, 6.
- Proposed splits up xenial -> disco over different days.
- Start vmtest-devel-amd64-proposed a bit later.