### PR TITLE
admin-master-enable: use server-team-jenkins-be.internal

### DIFF
--- a/admin/admin-master-enable.yaml
+++ b/admin/admin-master-enable.yaml
@@ -28,5 +28,5 @@
           #!/bin/bash -eux
           rm -rf *
 
-          wget https://jenkins.ubuntu.com/server/jnlpJars/jenkins-cli.jar
+          wget http://server-team-jenkins-be.internal:8080/server/jnlpJars/jenkins-cli.jar
           java -jar jenkins-cli.jar -s http://server-team-jenkins-be.internal:8080/server/ -auth @/home/ubuntu/.jenkins/auth online-node ""


### PR DESCRIPTION
Download jenkins-cli.jar from http://server-team-jenkins-be.internal:8080
instead of using jenkins.ubuntu.com, which at the moment can't be
reached from the Internet per (temporary?) IS policy.