### PR TITLE
cloud-init copr build: use longer retry intervals

### DIFF
--- a/cloud-init/centos.yaml
+++ b/cloud-init/centos.yaml
@@ -28,7 +28,7 @@
     builders:
       - shell: |
           #!/bin/bash
-          set -e
+          set -ex
           rm -rf *
 
           git clone --depth 1 https://github.com/CanonicalLtd/server-test-scripts
@@ -47,7 +47,7 @@
           cd server-test-scripts/cloud-init
 
           retry_cmd="./copr_build.py --dev --srpm $SRPM"
-          for i in {1..3}; do [ $i -gt 1 ] && sleep 20m; $retry_cmd && s=0 && break || s=$?; done; (exit $s)
+          for i in 0 5m 30m 1h; do sleep $i; $retry_cmd && s=0 && break || s=$?; done; (exit $s)
 
 - job:
     name: cloud-init-copr-test-7


### PR DESCRIPTION
And execute script in xtrace mode (set -x).