### PR TITLE
travis: use JJB 2.0.3 (the version in Bionic)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: python
-install: "pip install jenkins-job-builder==2.10.1"
+install: "pip install jenkins-job-builder==2.0.3"
 script: ./test-jenkins-jobs


### PR DESCRIPTION
Now that torkoal has been redeployed with Bionic we can use the
jenkins-job-builder Ubuntu package insead of installing from PyPI.
Let's make Travis run the tests with the same version we're going to
use from now on.