### PR TITLE
admin-jobs-update: fix the force_update parameter

### DIFF
--- a/admin/deploy.yaml
+++ b/admin/deploy.yaml
@@ -31,7 +31,6 @@
     builders:
       - shell: |
           #!/bin/bash -eux
-          force_update={force_update}
           rm -rf *
           git clone https://github.com/CanonicalLtd/server-jenkins-jobs
           cd server-jenkins-jobs


### PR DESCRIPTION
force_update is a parameter, i.e. an environment variable.
It doesn't have to be set from a Jenkins variable.