### PR TITLE
explicitly set 'fail: true' in the timeout wrappers

### DIFF
--- a/cloud-init/jobs-ci.yaml
+++ b/cloud-init/jobs-ci.yaml
@@ -24,6 +24,7 @@
         # We run every 15 minutes, and runs usually take ~7 minutes
         - timeout:
             timeout: 15
+            fail: true
     builders:
         - shell: |
             #!/bin/bash -x
@@ -44,6 +45,7 @@
         # We run every 15 minutes, and runs usually take ~30 seconds
         - timeout:
             timeout: 15
+            fail: true
     builders:
         - shell: |
             #!/bin/bash

--- a/curtin/jobs-ci.yaml
+++ b/curtin/jobs-ci.yaml
@@ -23,6 +23,7 @@
         # We run every 15 minutes, and runs usually take a few seconds
         - timeout:
             timeout: 15
+            fail: true
     builders:
         - shell: |
             #!/bin/bash -x
@@ -43,6 +44,7 @@
         # We run every 15 minutes, and runs usually take a few seconds
         - timeout:
             timeout: 15
+            fail: true
     builders:
         - shell: |
             #!/bin/bash

--- a/simplestreams/jobs-ci.yaml
+++ b/simplestreams/jobs-ci.yaml
@@ -23,6 +23,7 @@
         # We run every 15 minutes, and runs usually take a few seconds
         - timeout:
             timeout: 15
+            fail: true
     builders:
       - shell: |
           #!/bin/bash -x
@@ -44,6 +45,7 @@
         # We run every 15 minutes, and runs usually take a few seconds
         - timeout:
             timeout: 15
+            fail: true
     builders:
         - shell: |
             #!/bin/bash


### PR DESCRIPTION
The JJB default is to take no action if the timeout is reached; the
action has to be set explicitly.