### PR TITLE
JLP: preserve the launchpadTrigger RC; drop deprecated parameters

### DIFF
--- a/admin/admin-git.yaml
+++ b/admin/admin-git.yaml
@@ -41,7 +41,6 @@
 
           voteOnMergeProposal --status=${TEST_RESULT} \
                               --build-url=${TEST_URL} \
-                              --branch=${MERGE_BRANCH} \
                               --merge-proposal=${MERGE_URL} \
                               --revision=${MERGE_REVISION}
 

--- a/cloud-init/jobs-ci.yaml
+++ b/cloud-init/jobs-ci.yaml
@@ -34,8 +34,6 @@
                              --branch=lp:cloud-init \
                              --trigger-ci
 
-            exit 0
-
 - job:
     name: cloud-init-autoland-trigger
     node: metal-amd64

--- a/curtin/jobs-ci.yaml
+++ b/curtin/jobs-ci.yaml
@@ -33,8 +33,6 @@
                              --branch=lp:curtin \
                              --trigger-ci
 
-            exit 0
-
 - job:
     name: curtin-autoland-trigger
     node: metal-amd64

--- a/git-ubuntu/jobs-ci.yaml
+++ b/git-ubuntu/jobs-ci.yaml
@@ -29,8 +29,6 @@
                              --branch=lp:usd-importer \
                              --trigger-ci
 
-            exit 0
-
 - job:
     name: git-ubuntu-ci
     parameters:

--- a/simplestreams/jobs-ci.yaml
+++ b/simplestreams/jobs-ci.yaml
@@ -31,10 +31,7 @@
           launchpadTrigger --lock-name=${JOB_NAME} \
                            --job=simplestreams-ci \
                            --branch=lp:simplestreams \
-                           --trigger-ci \
-                           --repo_type=git
-
-          exit 0
+                           --trigger-ci
 
 - job:
     name: simplestreams-autoland-trigger
@@ -54,8 +51,7 @@
             launchpadTrigger --lock-name=${JOB_NAME} \
                              --job=simplestreams-autoland-test \
                              --branch=lp:simplestreams \
-                             --autoland \
-                             --repo_type=git
+                             --autoland
 
 - job:
     name: simplestreams-ci


### PR DESCRIPTION
Deprecated parameters:
 - `launchpadTrigger --repo-type` (only Git is supported)
 - `admin/admin-git.yaml --branch`