### PR TITLE
git-ubuntu-ci: use double quotes when setting VM_NAME

### DIFF
--- a/git-ubuntu/jobs-ci.yaml
+++ b/git-ubuntu/jobs-ci.yaml
@@ -69,7 +69,7 @@
         }
 
         environment {
-            VM_NAME = 'gitubuntu-ci-${currentBuild.getNumber()}'
+            VM_NAME = "gitubuntu-ci-${currentBuild.getNumber()}"
         }
 
         stages {
@@ -139,7 +139,7 @@
         agent { label 'torkoal' }
 
         environment {
-            VM_NAME = 'gitubuntu-ci-nightly-${currentBuild.getNumber()}'
+            VM_NAME = "gitubuntu-ci-nightly-${currentBuild.getNumber()}"
         }
 
         stages {


### PR DESCRIPTION
Apparently in newer Jenkins versions variables set with single quotes
are not expanded anymore. Switch to double quotes.