### PR TITLE
curtin-ci: update param descriptions, order to match cloud-init-ci

### DIFF
--- a/curtin/jobs-ci.yaml
+++ b/curtin/jobs-ci.yaml
@@ -57,9 +57,9 @@
     name: curtin-ci
     parameters:
         - landing-candidate
+        - landing-candidate-branch
         - candidate-revision
         - merge-proposal
-        - landing-candidate-branch
         - use-description-for-commit
     project-type: matrix
     axes:

--- a/curtin/parameters.yaml
+++ b/curtin/parameters.yaml
@@ -21,7 +21,7 @@
       - string:
           name: landing_candidate
           default: https://git.launchpad.net/curtin
-          description: Candidate git repo to test
+          description: Candidate git repo to test (e.g. https://git.launchpad.net/~raharper/curtin)
 
 - parameter:
     name: landing-candidate-branch
@@ -29,21 +29,21 @@
       - string:
           name: landing_candidate_branch
           default: master
-          description: Git branch name for testing
+          description: Git branch name for testing (e.g. 'master')
 
 - parameter:
     name: candidate-revision
     parameters:
       - string:
           name: candidate_revision
-          description: Revision of the branch to test.
+          description: Revision of the branch to test. (e.g. 'c6af5b9a1648c208c82b3a2704668391abadd8ab')
 
 - parameter:
     name: merge-proposal
     parameters:
       - string:
           name: merge_proposal
-          description: Merge proposal to process to test.
+          description: Merge proposal to process to test. (e.g. https://code.launchpad.net/~raharper/curtin/+git/curtin/+merge/370800)
 
 - parameter:
     name: use-description-for-commit


### PR DESCRIPTION

When manually adding a branch for CI, make it easier to know what values to put in which input.