### PR TITLE
Run the CI jobs on any metal-amd64 node

### DIFF
--- a/cloud-init/jobs-ci.yaml
+++ b/cloud-init/jobs-ci.yaml
@@ -67,7 +67,7 @@
     sandbox: True
     dsl: |
       pipeline {
-        agent { label 'torkoal' }
+        agent { label 'metal-amd64' }
         parameters {
             string (
                 defaultValue: 'lp:cloud-init',
@@ -165,7 +165,7 @@
       - email-server-crew
     sandbox: True
     dsl: |
-      node('torkoal') {
+      node('metal-amd64') {
         try {
             stage ('Checkout') {
                 deleteDir()

--- a/git-ubuntu/jobs-ci.yaml
+++ b/git-ubuntu/jobs-ci.yaml
@@ -17,7 +17,7 @@
 
 - job:
     name: git-ubuntu-ci-trigger
-    node: torkoal
+    node: metal-amd64
     triggers:
         - timed: H/15 * * * *
     builders:
@@ -42,7 +42,7 @@
     sandbox: True
     dsl: |
       pipeline {
-        agent { label 'torkoal' }
+        agent { label 'metal-amd64' }
         parameters {
             string (
                 defaultValue: '',
@@ -134,7 +134,7 @@
     sandbox: True
     dsl: |
       pipeline {
-        agent { label 'torkoal' }
+        agent { label 'metal-amd64' }
 
         environment {
             VM_NAME = "gitubuntu-ci-nightly-${currentBuild.getNumber()}"


### PR DESCRIPTION
Run the CI jobs on any metal-amd64 node instead of forcing the jobs to
run on torkoal.