### PR TITLE
Run the table-flip daily triage job on any node

### DIFF
--- a/daily-triage/daily-triage.yaml
+++ b/daily-triage/daily-triage.yaml
@@ -17,7 +17,6 @@
 
 - job:
     name: tableflip-daily-triage
-    node: torkoal
     triggers:
       - timed: "H(0-20) 6 * * 1-5"
     publishers:


### PR DESCRIPTION
All the nodes should now be able to run this job. The job will now run
on any node setup with "Use this node as much as possible", which we
normally reserve for the metal-amd64 nodes.