### PR TITLE
Delete the curtin-vmtest-sync-images job

### DIFF
--- a/curtin/default.yaml
+++ b/curtin/default.yaml
@@ -33,7 +33,6 @@
       - curtin-vmtest-devel-amd64-proposed
       - curtin-vmtest-devel-ppc64el
       - curtin-vmtest-devel-s390x
-      - curtin-vmtest-sync-images
       - curtin-vmtest-daily-x
       - curtin-vmtest-daily-b
       - curtin-vmtest-proposed-b

--- a/curtin/jobs-vmtest.yaml
+++ b/curtin/jobs-vmtest.yaml
@@ -16,20 +16,6 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 
 - job:
-    name: curtin-vmtest-sync-images
-    node: torkoal
-    triggers:
-        - timed: "H 11,23 * * *"
-    builders:
-        - shell: |
-            #!/bin/bash -x
-            rm -Rf curtin
-            git clone --branch=master https://git.launchpad.net/curtin
-            cd curtin
-
-            ./tools/vmtest-sync-images
-
-- job:
     name: curtin-vmtest-devel-amd64
     node: torkoal
     parameters:


### PR DESCRIPTION
The vmtests already sync the needed images before running, so this job
is not really needed.

As we plan to run the vmtests across a number of arches a single job
wouldn't have worked well, as Jenkins runs it on a single node, while
we'd like to update the images on all the nodes.