### PR TITLE
curtin-ci: run jenkins-runner with --skip-images-dirlock

### DIFF
--- a/curtin/jobs-ci.yaml
+++ b/curtin/jobs-ci.yaml
@@ -111,7 +111,7 @@
             no_proxy=launchpad.net https_proxy="http://squid.internal:3128" tox
 
             if [ "$(arch)" == "x86_64" ]; then
-                ./tools/jenkins-runner -p 4 tests/vmtests/test_basic.py:XenialGATestBasic tests/vmtests/test_basic.py:BionicTestBasic
+                ./tools/jenkins-runner --skip-images-dirlock -p 4 tests/vmtests/test_basic.py:XenialGATestBasic tests/vmtests/test_basic.py:BionicTestBasic
             fi
 
 - job:


### PR DESCRIPTION
The --skip-images-dirlock gives jenkins-runner more priority over
vmtest-sync-images, allowing the curtin-ci job to run immediately
even if a vmtest-sync-images process is waiting.

The jenkins-runner will still wait if vmtest-sync-images is actually
updateing the images, and not just waiting for its turn.