### PR TITLE
Replace the curtin-vmtest-sync-images job with a builder

### DIFF
--- a/curtin/default.yaml
+++ b/curtin/default.yaml
@@ -34,7 +34,6 @@
       - curtin-vmtest-devel-arm64
       - curtin-vmtest-devel-ppc64el
       - curtin-vmtest-devel-s390x
-      - curtin-vmtest-sync-images
       - curtin-vmtest-daily-x
       - curtin-vmtest-daily-b
       - curtin-vmtest-proposed-b

--- a/curtin/jobs-vmtest-daily.yaml
+++ b/curtin/jobs-vmtest-daily.yaml
@@ -30,7 +30,6 @@
         - email-server-crew
         - archive-results
     builders:
-      - curtin-vmtest-sync-images
       - vmtest-daily:
           release: xenial
           nose_args: nose_args
@@ -50,7 +49,6 @@
         - email-server-crew
         - archive-results
     builders:
-      - curtin-vmtest-sync-images
       - vmtest-daily:
           release: bionic
           nose_args: nose_args
@@ -59,6 +57,7 @@
 - builder:
     name: vmtest-daily
     builders:
+      - curtin-vmtest-sync-images
       - shell: |
           RELEASE={release}
           TYPE="daily"

--- a/curtin/jobs-vmtest-daily.yaml
+++ b/curtin/jobs-vmtest-daily.yaml
@@ -30,6 +30,7 @@
         - email-server-crew
         - archive-results
     builders:
+      - curtin-vmtest-sync-images
       - vmtest-daily:
           release: xenial
           nose_args: nose_args
@@ -49,6 +50,7 @@
         - email-server-crew
         - archive-results
     builders:
+      - curtin-vmtest-sync-images
       - vmtest-daily:
           release: bionic
           nose_args: nose_args

--- a/curtin/jobs-vmtest-proposed.yaml
+++ b/curtin/jobs-vmtest-proposed.yaml
@@ -93,7 +93,6 @@
         - email-server-crew
         - archive-results
     builders:
-      - curtin-vmtest-sync-images
       - vmtest-proposed:
           release: xenial
 
@@ -108,7 +107,6 @@
         - email-server-crew
         - archive-results
     builders:
-      - curtin-vmtest-sync-images
       - vmtest-proposed:
           release: bionic
 
@@ -123,7 +121,6 @@
         - email-server-crew
         - archive-results
     builders:
-      - curtin-vmtest-sync-images
       - vmtest-proposed:
           release: disco
 
@@ -138,13 +135,13 @@
         - email-server-crew
         - archive-results
     builders:
-      - curtin-vmtest-sync-images
       - vmtest-proposed:
           release: eoan
 
 - builder:
     name: vmtest-proposed
     builders:
+      - curtin-vmtest-sync-images
       - shell: |
           RELEASE={release}
           TYPE="proposed"

--- a/curtin/jobs-vmtest-proposed.yaml
+++ b/curtin/jobs-vmtest-proposed.yaml
@@ -93,6 +93,7 @@
         - email-server-crew
         - archive-results
     builders:
+      - curtin-vmtest-sync-images
       - vmtest-proposed:
           release: xenial
 
@@ -107,6 +108,7 @@
         - email-server-crew
         - archive-results
     builders:
+      - curtin-vmtest-sync-images
       - vmtest-proposed:
           release: bionic
 
@@ -121,6 +123,7 @@
         - email-server-crew
         - archive-results
     builders:
+      - curtin-vmtest-sync-images
       - vmtest-proposed:
           release: disco
 
@@ -135,6 +138,7 @@
         - email-server-crew
         - archive-results
     builders:
+      - curtin-vmtest-sync-images
       - vmtest-proposed:
           release: eoan
 

--- a/curtin/jobs-vmtest.yaml
+++ b/curtin/jobs-vmtest.yaml
@@ -15,19 +15,6 @@
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 
-- job:
-    name: curtin-vmtest-sync-images
-    node: torkoal
-    triggers:
-        - timed: "H 11,23 * * *"
-    builders:
-        - shell: |
-            #!/bin/bash -x
-            rm -Rf curtin
-            git clone --branch=master https://git.launchpad.net/curtin
-            cd curtin
-
-            ./tools/vmtest-sync-images
 
 - job:
     name: curtin-vmtest-devel-amd64
@@ -41,6 +28,7 @@
     triggers:
         - timed: "H 0 * * *"
     builders:
+        - curtin-vmtest-sync-images
         - curtin-vmtest
     properties:
       - build-discarder:
@@ -63,6 +51,7 @@
             default_nose_args: tests/vmtests/test_uefi_basic.py
         - vmtest-add-repos
     builders:
+        - curtin-vmtest-sync-images
         - curtin-vmtest
     properties:
       - build-discarder:
@@ -85,6 +74,7 @@
             default_nose_args: tests/vmtests/test_basic.py
         - vmtest-add-repos
     builders:
+        - curtin-vmtest-sync-images
         - curtin-vmtest
     properties:
       - build-discarder:
@@ -105,6 +95,7 @@
             default_nose_args:
         - vmtest-add-repos
     builders:
+        - curtin-vmtest-sync-images
         - curtin-vmtest
     properties:
       - build-discarder:
@@ -125,6 +116,7 @@
             default_nose_args:
         - vmtest-add-repos
     builders:
+        - curtin-vmtest-sync-images
         - curtin-vmtest
     properties:
       - build-discarder:
@@ -157,7 +149,31 @@
         - email-server-crew
         - archive-results
     builders:
+      - curtin-vmtest-sync-images
       - curtin-vmtest
+
+- builder:
+    name: curtin-vmtest-sync-images
+    builders:
+        - shell: |
+            #!/bin/bash
+
+            set -ufx -o pipefail
+
+            # The images have been updated recently enough => exit 0
+            test "$(find /srv/images/.vmtest-data -maxdepth 0 -mmin -1080)" && exit 0
+
+            # Is vmtest-sync-images already running?
+            vsc_count=$(pgrep -c vmtest-sync-images)
+            rc=$?
+            ((rc > 1)) && exit 1 # pgrep error
+            ((vsc_count == 1)) && exit 0 # vmtest-sync-images already running
+            ((vsc_count >= 2)) && exit 1 # many vmtest-sync-images running => heads-up
+
+            git clone https://git.launchpad.net/curtin curtin-sync-images || exit 1
+            cd curtin-sync-images || exit 1
+
+            ./tools/vmtest-sync-images || exit 1
 
 - builder:
     name: curtin-vmtest

--- a/curtin/jobs-vmtest.yaml
+++ b/curtin/jobs-vmtest.yaml
@@ -28,7 +28,6 @@
     triggers:
         - timed: "H 0 * * *"
     builders:
-        - curtin-vmtest-sync-images
         - curtin-vmtest
     properties:
       - build-discarder:
@@ -51,7 +50,6 @@
             default_nose_args: tests/vmtests/test_uefi_basic.py
         - vmtest-add-repos
     builders:
-        - curtin-vmtest-sync-images
         - curtin-vmtest
     properties:
       - build-discarder:
@@ -74,7 +72,6 @@
             default_nose_args: tests/vmtests/test_basic.py
         - vmtest-add-repos
     builders:
-        - curtin-vmtest-sync-images
         - curtin-vmtest
     properties:
       - build-discarder:
@@ -95,7 +92,6 @@
             default_nose_args:
         - vmtest-add-repos
     builders:
-        - curtin-vmtest-sync-images
         - curtin-vmtest
     properties:
       - build-discarder:
@@ -116,7 +112,6 @@
             default_nose_args:
         - vmtest-add-repos
     builders:
-        - curtin-vmtest-sync-images
         - curtin-vmtest
     properties:
       - build-discarder:
@@ -149,7 +144,6 @@
         - email-server-crew
         - archive-results
     builders:
-      - curtin-vmtest-sync-images
       - curtin-vmtest
 
 - builder:
@@ -178,6 +172,7 @@
 - builder:
     name: curtin-vmtest
     builders:
+        - curtin-vmtest-sync-images
         - shell: |
             if [ "$(hostname)" = "torkoal" ]; then
                 export TMPDIR=/var/lib/jenkins/tmp/


### PR DESCRIPTION
The builder is run before each vmtest run, checks if the images have been
updated recently enough and runs vmtest-sync-images if necessary. This
will update the images on any node the vmtests are run on.

The builder is not run as part of the curtin-ci job, as we want it to
run as soon as possible, with the existing images.