### PR TITLE
curtin: use the timestamps and workspace-cleanup wrappers

### DIFF
--- a/curtin/default.yaml
+++ b/curtin/default.yaml
@@ -1,3 +1,4 @@
+---
 # Ubuntu Server QA Jenkins Jobs
 # Copyright (C) 2017 Canonical Ltd.
 #
@@ -14,6 +15,23 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+- defaults:
+    name: global
+    description: |
+        Curtin Ubuntu Server QA Jenkins Job
+
+        *** STOP ***
+        Do NOT edit this job through the web
+        This job is managed by Jenkins Job Builder and stored on Github via the URL below:
+        https://github.com/CanonicalLtd/server-jenkins-jobs
+        *** STOP ***
+    properties:
+      - build-discarder:
+          num-to-keep: 25
+    publishers:
+      - email-server-crew
+
 
 - project:
     name: curtin
@@ -45,22 +63,6 @@
       - curtin-vmtest-proposed-x
       - curtin-vmtest-proposed-x-trigger
 
-
-- defaults:
-    name: global
-    description: |
-        Curtin Ubuntu Server QA Jenkins Job
-
-        *** STOP ***
-        Do NOT edit this job through the web
-        This job is managed by Jenkins Job Builder and stored on Github via the URL below:
-        https://github.com/CanonicalLtd/server-jenkins-jobs
-        *** STOP ***
-    properties:
-      - build-discarder:
-          num-to-keep: 25
-    publishers:
-      - email-server-crew
 
 - publisher:
     name: email-server-crew

--- a/curtin/jobs-ci.yaml
+++ b/curtin/jobs-ci.yaml
@@ -1,3 +1,4 @@
+---
 # Ubuntu Server QA Jenkins Jobs
 # Copyright (C) 2016 Canonical Ltd.
 #
@@ -18,50 +19,50 @@
 - job:
     name: curtin-ci-trigger
     triggers:
-        - timed: H/15 * * * *
+      - timed: H/15 * * * *
     wrappers:
-        # We run every 15 minutes, and runs usually take a few seconds
-        - timeout:
-            timeout: 15
-            fail: true
+      # We run every 15 minutes, and runs usually take a few seconds
+      - timeout:
+          timeout: 15
+          fail: true
     builders:
-        - shell: |
-            #!/bin/bash
-            set -eux
+      - shell: |
+          #!/bin/bash
+          set -eux
 
-            launchpadTrigger --lock-name=${JOB_NAME} \
-                             --job=curtin-ci \
-                             --branch=lp:curtin \
-                             --trigger-ci
+          launchpadTrigger --lock-name=${JOB_NAME} \
+                           --job=curtin-ci \
+                           --branch=lp:curtin \
+                           --trigger-ci
 
 - job:
     name: curtin-autoland-trigger
     node: metal-amd64
     triggers:
-        - timed: H/15 * * * *
+      - timed: H/15 * * * *
     wrappers:
-        # We run every 15 minutes, and runs usually take a few seconds
-        - timeout:
-            timeout: 15
-            fail: true
+      # We run every 15 minutes, and runs usually take a few seconds
+      - timeout:
+          timeout: 15
+          fail: true
     builders:
-        - shell: |
-            #!/bin/bash
-            set -eux
+      - shell: |
+          #!/bin/bash
+          set -eux
 
-            launchpadTrigger --lock-name=${JOB_NAME} \
-                             --job=curtin-autoland-test \
-                             --branch=lp:curtin \
-                             --autoland
+          launchpadTrigger --lock-name=${JOB_NAME} \
+                           --job=curtin-autoland-test \
+                           --branch=lp:curtin \
+                           --autoland
 
 - job:
     name: curtin-ci
     parameters:
-        - landing-candidate
-        - landing-candidate-branch
-        - candidate-revision
-        - merge-proposal
-        - use-description-for-commit
+      - landing-candidate
+      - landing-candidate-branch
+      - candidate-revision
+      - merge-proposal
+      - use-description-for-commit
     project-type: matrix
     axes:
       - axis:
@@ -79,43 +80,43 @@
           excludes: 'output/debug.log, **/*img'
           allow-empty: true
       - trigger-parameterized-builds:
-        - project: admin-lp-git-vote
-          condition: UNSTABLE_OR_WORSE
-          predefined-parameters: |
-            MERGE_BRANCH=${landing_candidate}
-            MERGE_REVISION=${candidate_revision}
-            MERGE_URL=${merge_proposal}
-            TEST_RESULT=FAILED
-            TEST_URL=${BUILD_URL}
+          - project: admin-lp-git-vote
+            condition: UNSTABLE_OR_WORSE
+            predefined-parameters: |
+              MERGE_BRANCH=${landing_candidate}
+              MERGE_REVISION=${candidate_revision}
+              MERGE_URL=${merge_proposal}
+              TEST_RESULT=FAILED
+              TEST_URL=${BUILD_URL}
       - trigger-parameterized-builds:
-        - project: admin-lp-git-vote
-          condition: SUCCESS
-          predefined-parameters: |
-            MERGE_BRANCH=${landing_candidate}
-            MERGE_REVISION=${candidate_revision}
-            MERGE_URL=${merge_proposal}
-            TEST_RESULT=PASSED
-            TEST_URL=${BUILD_URL}
+          - project: admin-lp-git-vote
+            condition: SUCCESS
+            predefined-parameters: |
+              MERGE_BRANCH=${landing_candidate}
+              MERGE_REVISION=${candidate_revision}
+              MERGE_URL=${merge_proposal}
+              TEST_RESULT=PASSED
+              TEST_URL=${BUILD_URL}
     wrappers:
-        - timestamps
-        - workspace-cleanup
+      - timestamps
+      - workspace-cleanup
     builders:
-        - shell: |
-            #!/bin/bash
-            set -eux
+      - shell: |
+          #!/bin/bash
+          set -eux
 
-            branch=${landing_candidate//lp:/https://git.launchpad.net/}
-            git clone --branch=${landing_candidate_branch} $branch curtin-${BUILD_NUMBER}
-            cd curtin-${BUILD_NUMBER}
-            git rev-parse HEAD
-            git remote add upstream https://git.launchpad.net/curtin
-            git fetch upstream --tags
+          branch=${landing_candidate//lp:/https://git.launchpad.net/}
+          git clone --branch=${landing_candidate_branch} $branch curtin-${BUILD_NUMBER}
+          cd curtin-${BUILD_NUMBER}
+          git rev-parse HEAD
+          git remote add upstream https://git.launchpad.net/curtin
+          git fetch upstream --tags
 
-            no_proxy=launchpad.net https_proxy="http://squid.internal:3128" tox
+          no_proxy=launchpad.net https_proxy="http://squid.internal:3128" tox
 
-            if [ "$(arch)" == "x86_64" ]; then
-                ./tools/jenkins-runner --skip-images-dirlock -p 4 tests/vmtests/test_basic.py:XenialGATestBasic tests/vmtests/test_basic.py:BionicTestBasic
-            fi
+          if [ "$(arch)" == "x86_64" ]; then
+              ./tools/jenkins-runner --skip-images-dirlock -p 4 tests/vmtests/test_basic.py:XenialGATestBasic tests/vmtests/test_basic.py:BionicTestBasic
+          fi
 
 - job:
     name: curtin-autoland-test
@@ -136,21 +137,21 @@
     auth-token: BUILD_ME
     publishers:
       - trigger-parameterized-builds:
-        - project: admin-lp-git-autoland
-          condition: UNSTABLE_OR_WORSE
-          predefined-parameters: |
-            MERGE_REVISION=${candidate_revision}
-            MERGE_URL=${merge_proposal}
-            TEST_RESULT=FAILED
-            TEST_URL=${BUILD_URL}
+          - project: admin-lp-git-autoland
+            condition: UNSTABLE_OR_WORSE
+            predefined-parameters: |
+              MERGE_REVISION=${candidate_revision}
+              MERGE_URL=${merge_proposal}
+              TEST_RESULT=FAILED
+              TEST_URL=${BUILD_URL}
       - trigger-parameterized-builds:
-        - project: admin-lp-git-autoland
-          condition: SUCCESS
-          predefined-parameters: |
-            MERGE_REVISION=${candidate_revision}
-            MERGE_URL=${merge_proposal}
-            TEST_RESULT=PASSED
-            TEST_URL=${BUILD_URL}
+          - project: admin-lp-git-autoland
+            condition: SUCCESS
+            predefined-parameters: |
+              MERGE_REVISION=${candidate_revision}
+              MERGE_URL=${merge_proposal}
+              TEST_RESULT=PASSED
+              TEST_URL=${BUILD_URL}
     wrappers:
       - timestamps
       - workspace-cleanup

--- a/curtin/jobs-ci.yaml
+++ b/curtin/jobs-ci.yaml
@@ -26,8 +26,9 @@
             fail: true
     builders:
         - shell: |
-            #!/bin/bash -x
-            rm -rf *
+            #!/bin/bash
+            set -eux
+
             launchpadTrigger --lock-name=${JOB_NAME} \
                              --job=curtin-ci \
                              --branch=lp:curtin \
@@ -95,12 +96,14 @@
             MERGE_URL=${merge_proposal}
             TEST_RESULT=PASSED
             TEST_URL=${BUILD_URL}
+    wrappers:
+        - timestamps
+        - workspace-cleanup
     builders:
         - shell: |
             #!/bin/bash
             set -eux
 
-            rm -rf *
             branch=${landing_candidate//lp:/https://git.launchpad.net/}
             git clone --branch=${landing_candidate_branch} $branch curtin-${BUILD_NUMBER}
             cd curtin-${BUILD_NUMBER}
@@ -148,12 +151,14 @@
             MERGE_URL=${merge_proposal}
             TEST_RESULT=PASSED
             TEST_URL=${BUILD_URL}
+    wrappers:
+      - timestamps
+      - workspace-cleanup
     builders:
       - shell: |
           #!/bin/bash
           set -eux
 
-          rm -rf *
           git clone lp:curtin
           cd curtin
 

--- a/curtin/jobs-vmtest-daily.yaml
+++ b/curtin/jobs-vmtest-daily.yaml
@@ -1,3 +1,4 @@
+---
 # Ubuntu Server QA Jenkins Jobs
 # Copyright (C) 2017 Canonical Ltd.
 #
@@ -19,46 +20,45 @@
     name: curtin-vmtest-daily-x
     node: torkoal
     parameters:
-        - nose-args:
-            default_nose_args:
+      - nose-args:
+          default_nose_args:
     triggers:
-        - timed: "H 4 * * 1,3,5"
+      - timed: "H 4 * * 1,3,5"
     properties:
-        - build-discarder:
-            num-to-keep: 5
+      - build-discarder:
+          num-to-keep: 5
     publishers:
-        - email-server-crew
-        - archive-results
+      - email-server-crew
+      - archive-results
     wrappers:
-        - timestamps
-        - workspace-cleanup
+      - timestamps
+      - workspace-cleanup
     builders:
-        - vmtest-daily:
-            release: xenial
-            nose_args: nose_args
+      - vmtest-daily:
+          release: xenial
+          nose_args: nose_args
 
 - job:
     name: curtin-vmtest-daily-b
     node: torkoal
     parameters:
-        - nose-args:
-            default_nose_args:
+      - nose-args:
+          default_nose_args:
     triggers:
-        - timed: "H 4 * * 2,4,6"
+      - timed: "H 4 * * 2,4,6"
     properties:
       - build-discarder:
           num-to-keep: 5
     publishers:
-        - email-server-crew
-        - archive-results
+      - email-server-crew
+      - archive-results
     wrappers:
-        - timestamps
-        - workspace-cleanup
+      - timestamps
+      - workspace-cleanup
     builders:
-        - vmtest-daily:
-            release: bionic
-            nose_args: nose_args
-
+      - vmtest-daily:
+          release: bionic
+          nose_args: nose_args
 
 - builder:
     name: vmtest-daily

--- a/curtin/jobs-vmtest-daily.yaml
+++ b/curtin/jobs-vmtest-daily.yaml
@@ -24,15 +24,18 @@
     triggers:
         - timed: "H 4 * * 1,3,5"
     properties:
-      - build-discarder:
-          num-to-keep: 5
+        - build-discarder:
+            num-to-keep: 5
     publishers:
         - email-server-crew
         - archive-results
+    wrappers:
+        - timestamps
+        - workspace-cleanup
     builders:
-      - vmtest-daily:
-          release: xenial
-          nose_args: nose_args
+        - vmtest-daily:
+            release: xenial
+            nose_args: nose_args
 
 - job:
     name: curtin-vmtest-daily-b
@@ -48,16 +51,19 @@
     publishers:
         - email-server-crew
         - archive-results
+    wrappers:
+        - timestamps
+        - workspace-cleanup
     builders:
-      - vmtest-daily:
-          release: bionic
-          nose_args: nose_args
+        - vmtest-daily:
+            release: bionic
+            nose_args: nose_args
 
 
 - builder:
     name: vmtest-daily
     builders:
-      - curtin-vmtest-sync-images
+      - vmtest-sync-images
       - shell: |
           RELEASE={release}
           TYPE="daily"
@@ -67,7 +73,6 @@
           export CURTIN_VMTEST_CURTIN_EXE="curtin-from-container $LXC_NAME curtin"
           export CURTIN_VMTEST_SKIP_BY_DATE_BUGS="*"
 
-          rm -Rf curtin-* output
           git clone --branch=master https://git.launchpad.net/curtin curtin-$BUILD_NUMBER
           cd curtin-$BUILD_NUMBER
           PATH="$PWD/tools:$PATH"

--- a/curtin/jobs-vmtest-proposed.yaml
+++ b/curtin/jobs-vmtest-proposed.yaml
@@ -22,7 +22,9 @@
     triggers:
       - timed: "H 10 * * 1,4"
     publishers:
-        - email-server-crew
+      - email-server-crew
+    wrappers:
+      - workspace-cleanup
     builders:
       - vmtest-proposed-trigger:
           release: xenial
@@ -34,7 +36,9 @@
     triggers:
       - timed: "H 10 * * 2,5"
     publishers:
-        - email-server-crew
+      - email-server-crew
+    wrappers:
+      - workspace-cleanup
     builders:
       - vmtest-proposed-trigger:
           release: bionic
@@ -46,7 +50,9 @@
     triggers:
       - timed: "H 10 * * 3"
     publishers:
-        - email-server-crew
+      - email-server-crew
+    wrappers:
+      - workspace-cleanup
     builders:
       - vmtest-proposed-trigger:
           release: disco
@@ -58,7 +64,9 @@
     triggers:
       - timed: "H 10 * * 7"
     publishers:
-        - email-server-crew
+      - email-server-crew
+    wrappers:
+      - workspace-cleanup
     builders:
       - vmtest-proposed-trigger:
           release: eoan
@@ -72,7 +80,6 @@
           set -e
           release={release}
           triggerwhat={triggerwhat}
-          rm -rf *
 
           git clone https://github.com/CanonicalLtd/server-test-scripts
           cd server-test-scripts/launchpad/
@@ -92,6 +99,9 @@
     publishers:
         - email-server-crew
         - archive-results
+    wrappers:
+      - timestamps
+      - workspace-cleanup
     builders:
       - vmtest-proposed:
           release: xenial
@@ -106,6 +116,9 @@
     publishers:
         - email-server-crew
         - archive-results
+    wrappers:
+      - timestamps
+      - workspace-cleanup
     builders:
       - vmtest-proposed:
           release: bionic
@@ -120,6 +133,9 @@
     publishers:
         - email-server-crew
         - archive-results
+    wrappers:
+      - timestamps
+      - workspace-cleanup
     builders:
       - vmtest-proposed:
           release: disco
@@ -134,6 +150,9 @@
     publishers:
         - email-server-crew
         - archive-results
+    wrappers:
+      - timestamps
+      - workspace-cleanup
     builders:
       - vmtest-proposed:
           release: eoan
@@ -141,7 +160,7 @@
 - builder:
     name: vmtest-proposed
     builders:
-      - curtin-vmtest-sync-images
+      - vmtest-sync-images
       - shell: |
           RELEASE={release}
           TYPE="proposed"
@@ -152,7 +171,6 @@
           export CURTIN_VMTEST_TAR_DISKS=1
           export CURTIN_VMTEST_SKIP_BY_DATE_BUGS="*"
 
-          rm -Rf curtin-* output
           pull-lp-source curtin "$RELEASE"-proposed
           cd curtin-*
           PATH="$PWD/tools:$PATH"

--- a/curtin/jobs-vmtest-proposed.yaml
+++ b/curtin/jobs-vmtest-proposed.yaml
@@ -1,3 +1,4 @@
+---
 # Ubuntu Server QA Jenkins Jobs
 # Copyright (C) 2017 Canonical Ltd.
 #
@@ -72,7 +73,6 @@
           release: eoan
           triggerwhat: curtin-vmtest-proposed-e
 
-
 - builder:
     name: vmtest-proposed-trigger
     builders:
@@ -89,6 +89,7 @@
             curl -X POST --netrc-file $JENKINS_HOME/jenkins-bot-creds http://server-team-jenkins-be.internal:8080/server/job/$triggerwhat/build?token=BUILD_ME
           fi
 
+
 - job:
     name: curtin-vmtest-proposed-x
     node: torkoal
@@ -97,8 +98,8 @@
       - build-discarder:
           num-to-keep: 5
     publishers:
-        - email-server-crew
-        - archive-results
+      - email-server-crew
+      - archive-results
     wrappers:
       - timestamps
       - workspace-cleanup
@@ -114,8 +115,8 @@
       - build-discarder:
           num-to-keep: 5
     publishers:
-        - email-server-crew
-        - archive-results
+      - email-server-crew
+      - archive-results
     wrappers:
       - timestamps
       - workspace-cleanup
@@ -131,8 +132,8 @@
       - build-discarder:
           num-to-keep: 5
     publishers:
-        - email-server-crew
-        - archive-results
+      - email-server-crew
+      - archive-results
     wrappers:
       - timestamps
       - workspace-cleanup
@@ -148,8 +149,8 @@
       - build-discarder:
           num-to-keep: 5
     publishers:
-        - email-server-crew
-        - archive-results
+      - email-server-crew
+      - archive-results
     wrappers:
       - timestamps
       - workspace-cleanup

--- a/curtin/jobs-vmtest.yaml
+++ b/curtin/jobs-vmtest.yaml
@@ -1,3 +1,4 @@
+---
 # Ubuntu Server QA Jenkins Jobs
 # Copyright (C) 2016-2017 Canonical Ltd.
 #
@@ -20,23 +21,23 @@
     name: curtin-vmtest-devel-amd64
     node: torkoal
     parameters:
-        - landing-candidate
-        - landing-candidate-branch
-        - nose-args:
-            default_nose_args:
-        - vmtest-add-repos
+      - landing-candidate
+      - landing-candidate-branch
+      - nose-args:
+          default_nose_args:
+      - vmtest-add-repos
     triggers:
-        - timed: "H 0 * * *"
+      - timed: "H 0 * * *"
     builders:
-        - vmtest-devel
+      - vmtest-devel
     properties:
-        - build-discarder:
-            num-to-keep: 10
+      - build-discarder:
+          num-to-keep: 10
     publishers:
-        - archive:
-            artifacts: 'output/**'
-            excludes: 'output/debug.log, **/*img'
-        - email-server-crew
+      - archive:
+          artifacts: 'output/**'
+          excludes: 'output/debug.log, **/*img'
+      - email-server-crew
     wrappers:
       - timestamps
       - workspace-cleanup
@@ -45,48 +46,48 @@
     name: curtin-vmtest-devel-arm64
     node: metal-arm64
     triggers:
-        - timed: "H H * * *"
+      - timed: "H H * * *"
     parameters:
-        - landing-candidate
-        - landing-candidate-branch
-        - nose-args:
-            default_nose_args: tests/vmtests/test_uefi_basic.py
-        - vmtest-add-repos
+      - landing-candidate
+      - landing-candidate-branch
+      - nose-args:
+          default_nose_args: tests/vmtests/test_uefi_basic.py
+      - vmtest-add-repos
     wrappers:
       - timestamps
       - workspace-cleanup
     builders:
-        - vmtest-devel
+      - vmtest-devel
     properties:
-        - build-discarder:
-            num-to-keep: 10
+      - build-discarder:
+          num-to-keep: 10
     publishers:
-        - archive:
-            artifacts: 'output/**'
-            excludes: 'output/debug.log, **/*img'
-        - email-server-crew
+      - archive:
+          artifacts: 'output/**'
+          excludes: 'output/debug.log, **/*img'
+      - email-server-crew
 
 - job:
     name: curtin-vmtest-devel-ppc64el
     node: metal-ppc64el
     triggers:
-        - timed: "H H * * *"
+      - timed: "H H * * *"
     parameters:
-        - landing-candidate
-        - landing-candidate-branch
-        - nose-args:
-            default_nose_args: tests/vmtests/test_basic.py
-        - vmtest-add-repos
+      - landing-candidate
+      - landing-candidate-branch
+      - nose-args:
+          default_nose_args: tests/vmtests/test_basic.py
+      - vmtest-add-repos
     builders:
-        - vmtest-devel
+      - vmtest-devel
     properties:
-        - build-discarder:
-            num-to-keep: 10
+      - build-discarder:
+          num-to-keep: 10
     publishers:
-        - archive:
-            artifacts: 'output/**'
-            excludes: 'output/debug.log, **/*img'
-        - email-server-crew
+      - archive:
+          artifacts: 'output/**'
+          excludes: 'output/debug.log, **/*img'
+      - email-server-crew
     wrappers:
       - timestamps
       - workspace-cleanup
@@ -95,21 +96,21 @@
     name: curtin-vmtest-devel-s390x
     node: metal-s390x
     parameters:
-        - landing-candidate
-        - landing-candidate-branch
-        - nose-args:
-            default_nose_args:
-        - vmtest-add-repos
+      - landing-candidate
+      - landing-candidate-branch
+      - nose-args:
+          default_nose_args:
+      - vmtest-add-repos
     builders:
-        - vmtest-devel
+      - vmtest-devel
     properties:
       - build-discarder:
           num-to-keep: 10
     publishers:
-        - archive:
-            artifacts: 'output/**'
-            excludes: 'output/debug.log, **/*img'
-        - email-server-crew
+      - archive:
+          artifacts: 'output/**'
+          excludes: 'output/debug.log, **/*img'
+      - email-server-crew
     wrappers:
       - timestamps
       - workspace-cleanup
@@ -118,20 +119,20 @@
     name: curtin-vmtest-devel-debug
     node: torkoal
     parameters:
-        - landing-candidate
-        - landing-candidate-branch
-        - nose-args:
-            default_nose_args:
-        - vmtest-add-repos
+      - landing-candidate
+      - landing-candidate-branch
+      - nose-args:
+          default_nose_args:
+      - vmtest-add-repos
     builders:
-        - vmtest-devel
+      - vmtest-devel
     properties:
       - build-discarder:
           num-to-keep: 5
     publishers:
-        - archive:
-            artifacts: 'output/**'
-            excludes: 'output/debug.log, **/*img'
+      - archive:
+          artifacts: 'output/**'
+          excludes: 'output/debug.log, **/*img'
     wrappers:
       - timestamps
       - workspace-cleanup
@@ -140,24 +141,24 @@
     name: curtin-vmtest-devel-amd64-proposed
     node: torkoal
     triggers:
-        - timed: "H 8 * * 7"
+      - timed: "H 8 * * 7"
     parameters:
-        - landing-candidate
-        - landing-candidate-branch
-        - nose-args:
-            default_nose_args:
-        - string:
-            name: vmtest_add_repos
-            default: "proposed"
-        - string:
-            name: vmtest_filters
-            default: "target_distro=ubuntu"
+      - landing-candidate
+      - landing-candidate-branch
+      - nose-args:
+          default_nose_args:
+      - string:
+          name: vmtest_add_repos
+          default: "proposed"
+      - string:
+          name: vmtest_filters
+          default: "target_distro=ubuntu"
     properties:
       - build-discarder:
           num-to-keep: 5
     publishers:
-        - email-server-crew
-        - archive-results
+      - email-server-crew
+      - archive-results
     builders:
       - vmtest-devel
     wrappers:
@@ -167,68 +168,68 @@
 - builder:
     name: vmtest-sync-images
     builders:
-        - shell: |
-            #!/bin/bash
+      - shell: |
+          #!/bin/bash
 
-            set -ufx -o pipefail
+          set -ufx -o pipefail
 
-            # The images have been updated recently enough => exit 0
-            test "$(find /srv/images/.vmtest-data -maxdepth 0 -mmin -1080)" && exit 0
+          # The images have been updated recently enough => exit 0
+          test "$(find /srv/images/.vmtest-data -maxdepth 0 -mmin -1080)" && exit 0
 
-            # Is vmtest-sync-images already running?
-            vsc_count=$(pgrep -c vmtest-sync-images)
-            rc=$?
-            ((rc > 1)) && exit 1 # pgrep error
-            ((vsc_count == 1)) && exit 0 # vmtest-sync-images already running
-            ((vsc_count >= 2)) && exit 1 # many vmtest-sync-images running => heads-up
+          # Is vmtest-sync-images already running?
+          vsc_count=$(pgrep -c vmtest-sync-images)
+          rc=$?
+          ((rc > 1)) && exit 1 # pgrep error
+          ((vsc_count == 1)) && exit 0 # vmtest-sync-images already running
+          ((vsc_count >= 2)) && exit 1 # many vmtest-sync-images running => heads-up
 
-            git clone https://git.launchpad.net/curtin curtin-sync-images || exit 1
-            cd curtin-sync-images || exit 1
+          git clone https://git.launchpad.net/curtin curtin-sync-images || exit 1
+          cd curtin-sync-images || exit 1
 
-            ./tools/vmtest-sync-images || exit 1
+          ./tools/vmtest-sync-images || exit 1
 
 - builder:
     name: vmtest-devel
     builders:
-        - vmtest-sync-images
-        - shell: |
-            if [ "$(hostname)" = "torkoal" ]; then
-                export TMPDIR=/var/lib/jenkins/tmp/
-            fi
-            if [ -n "${vmtest_add_repos}" ]; then
-                export CURTIN_VMTEST_ADD_REPOS=${vmtest_add_repos}
-            fi
+      - vmtest-sync-images
+      - shell: |
+          if [ "$(hostname)" = "torkoal" ]; then
+              export TMPDIR=/var/lib/jenkins/tmp/
+          fi
+          if [ -n "${vmtest_add_repos}" ]; then
+              export CURTIN_VMTEST_ADD_REPOS=${vmtest_add_repos}
+          fi
 
-            # construct vmtest filters
-            filter_args=""
-            if [ -n "${vmtest_filters}" ]; then
-                f=""
-                for f in ${vmtest_filters}; do
-                    filter_args="$filter_args --filter=$f"
-                done
-            fi
-            echo "test filter args: \"$filter_args\""
+          # construct vmtest filters
+          filter_args=""
+          if [ -n "${vmtest_filters}" ]; then
+              f=""
+              for f in ${vmtest_filters}; do
+                  filter_args="$filter_args --filter=$f"
+              done
+          fi
+          echo "test filter args: \"$filter_args\""
 
-            # Helpful in debugging, but fill up Jenkins if all test fail
-            # export CURTIN_VMTEST_KEEP_DATA_FAIL=all
-            # export CURTIN_VMTEST_TAR_DISKS=1
+          # Helpful in debugging, but fill up Jenkins if all test fail
+          # export CURTIN_VMTEST_KEEP_DATA_FAIL=all
+          # export CURTIN_VMTEST_TAR_DISKS=1
 
-            git clone --branch=${landing_candidate_branch} ${landing_candidate} curtin-${BUILD_NUMBER}
-            cd curtin-${BUILD_NUMBER}
-            git remote add upstream https://git.launchpad.net/curtin
-            git fetch upstream --tags
+          git clone --branch=${landing_candidate_branch} ${landing_candidate} curtin-${BUILD_NUMBER}
+          cd curtin-${BUILD_NUMBER}
+          git remote add upstream https://git.launchpad.net/curtin
+          git fetch upstream --tags
 
-            ./tools/vmtest-system-setup
-            set +e
-            ./tools/jenkins-runner -p4 $filter_args ${nose_args}
-            RET=$?
+          ./tools/vmtest-system-setup
+          set +e
+          ./tools/jenkins-runner -p4 $filter_args ${nose_args}
+          RET=$?
 
-            cd ${WORKSPACE}
-            echo "cleanup: deleting links and image files"
-            find output -type l -delete
-            find output -type f -name "*.img" -delete
+          cd ${WORKSPACE}
+          echo "cleanup: deleting links and image files"
+          find output -type l -delete
+          find output -type f -name "*.img" -delete
 
-            # Return Skipped as Passed
-            [ $RET -eq 2 ] && RET=0
+          # Return Skipped as Passed
+          [ $RET -eq 2 ] && RET=0
 
-            exit $RET
+          exit $RET

--- a/curtin/jobs-vmtest.yaml
+++ b/curtin/jobs-vmtest.yaml
@@ -28,15 +28,18 @@
     triggers:
         - timed: "H 0 * * *"
     builders:
-        - curtin-vmtest
+        - vmtest-devel
     properties:
-      - build-discarder:
-          num-to-keep: 10
+        - build-discarder:
+            num-to-keep: 10
     publishers:
         - archive:
             artifacts: 'output/**'
             excludes: 'output/debug.log, **/*img'
         - email-server-crew
+    wrappers:
+      - timestamps
+      - workspace-cleanup
 
 - job:
     name: curtin-vmtest-devel-arm64
@@ -49,11 +52,14 @@
         - nose-args:
             default_nose_args: tests/vmtests/test_uefi_basic.py
         - vmtest-add-repos
+    wrappers:
+      - timestamps
+      - workspace-cleanup
     builders:
-        - curtin-vmtest
+        - vmtest-devel
     properties:
-      - build-discarder:
-          num-to-keep: 10
+        - build-discarder:
+            num-to-keep: 10
     publishers:
         - archive:
             artifacts: 'output/**'
@@ -72,15 +78,18 @@
             default_nose_args: tests/vmtests/test_basic.py
         - vmtest-add-repos
     builders:
-        - curtin-vmtest
+        - vmtest-devel
     properties:
-      - build-discarder:
-          num-to-keep: 10
+        - build-discarder:
+            num-to-keep: 10
     publishers:
         - archive:
             artifacts: 'output/**'
             excludes: 'output/debug.log, **/*img'
         - email-server-crew
+    wrappers:
+      - timestamps
+      - workspace-cleanup
 
 - job:
     name: curtin-vmtest-devel-s390x
@@ -92,7 +101,7 @@
             default_nose_args:
         - vmtest-add-repos
     builders:
-        - curtin-vmtest
+        - vmtest-devel
     properties:
       - build-discarder:
           num-to-keep: 10
@@ -101,6 +110,9 @@
             artifacts: 'output/**'
             excludes: 'output/debug.log, **/*img'
         - email-server-crew
+    wrappers:
+      - timestamps
+      - workspace-cleanup
 
 - job:
     name: curtin-vmtest-devel-debug
@@ -112,7 +124,7 @@
             default_nose_args:
         - vmtest-add-repos
     builders:
-        - curtin-vmtest
+        - vmtest-devel
     properties:
       - build-discarder:
           num-to-keep: 5
@@ -120,6 +132,9 @@
         - archive:
             artifacts: 'output/**'
             excludes: 'output/debug.log, **/*img'
+    wrappers:
+      - timestamps
+      - workspace-cleanup
 
 - job:
     name: curtin-vmtest-devel-amd64-proposed
@@ -144,10 +159,13 @@
         - email-server-crew
         - archive-results
     builders:
-      - curtin-vmtest
+      - vmtest-devel
+    wrappers:
+      - timestamps
+      - workspace-cleanup
 
 - builder:
-    name: curtin-vmtest-sync-images
+    name: vmtest-sync-images
     builders:
         - shell: |
             #!/bin/bash
@@ -170,9 +188,9 @@
             ./tools/vmtest-sync-images || exit 1
 
 - builder:
-    name: curtin-vmtest
+    name: vmtest-devel
     builders:
-        - curtin-vmtest-sync-images
+        - vmtest-sync-images
         - shell: |
             if [ "$(hostname)" = "torkoal" ]; then
                 export TMPDIR=/var/lib/jenkins/tmp/
@@ -195,8 +213,6 @@
             # export CURTIN_VMTEST_KEEP_DATA_FAIL=all
             # export CURTIN_VMTEST_TAR_DISKS=1
 
-            rm -Rf curtin-*
-            rm -Rf output
             git clone --branch=${landing_candidate_branch} ${landing_candidate} curtin-${BUILD_NUMBER}
             cd curtin-${BUILD_NUMBER}
             git remote add upstream https://git.launchpad.net/curtin

--- a/curtin/jobs.yaml
+++ b/curtin/jobs.yaml
@@ -18,11 +18,12 @@
 - job:
     name: curtin-build
     node: metal-amd64
+    wrappers:
+      - workspace-cleanup
     builders:
       - shell: |
           #!/bin/bash
           set -x
-          rm -rf *
           git clone https://git.launchpad.net/curtin build-$BUILD_NUMBER
           cd build-$BUILD_NUMBER
 
@@ -47,10 +48,12 @@
             - metal-ppc64el
             - metal-arm64
             - metal-s390x
+    wrappers:
+      - workspace-cleanup
     builders:
       - shell: |
-          #!/bin/bash -x
-          rm -rf *
+          #!/bin/bash
+          set -x
           git clone --branch=${branch} https://git.launchpad.net/curtin debug
           cd debug
 
@@ -64,11 +67,12 @@
           project: curtin-build
           threshold: FAILURE
       - email-server-crew
+    wrappers:
+      - workspace-cleanup
     builders:
       - shell: |
           #!/bin/bash
           set -x
-          rm -rf *
           git clone https://git.launchpad.net/curtin style
           cd style
 
@@ -99,10 +103,12 @@
             - metal-ppc64el
             - metal-arm64
             - metal-s390x
+    wrappers:
+      - workspace-cleanup
     builders:
       - shell: |
-          #!/bin/bash -x
-          rm -rf *
+          #!/bin/bash
+          set -x
           git clone https://git.launchpad.net/curtin tests
           cd tests
 
@@ -117,11 +123,12 @@
       - email-server-crew
       - junit:
           results: server-test-scripts/curtin/results.xml
+    wrappers:
+      - workspace-cleanup
     builders:
       - shell: |
           #!/bin/bash
           set -e
-          rm -rf *
           git clone https://github.com/CanonicalLtd/server-test-scripts
           cd server-test-scripts/curtin
           ./lp_build_status.py
@@ -132,15 +139,14 @@
     node: metal-amd64
     triggers:
       - timed: "H */4 * * *"
+    wrappers:
+      - workspace-cleanup
     builders:
       - shell: |
           #!/bin/bash
           set -eux
-          GIT_DIR="mirror"
 
-          if [ -d "$GIT_DIR" ]; then
-              rm -rf "$GIT_DIR"
-          fi
+          GIT_DIR="mirror"
 
           git clone --mirror https://git.launchpad.net/curtin "$GIT_DIR"
           cd "$GIT_DIR" || exit 1

--- a/curtin/jobs.yaml
+++ b/curtin/jobs.yaml
@@ -1,3 +1,4 @@
+---
 # Ubuntu Server QA Jenkins Jobs
 # Copyright (C) 2016-2017 Canonical Ltd.
 #

--- a/curtin/parameters.yaml
+++ b/curtin/parameters.yaml
@@ -1,3 +1,4 @@
+---
 # Ubuntu Server QA Jenkins Jobs
 # Copyright (C) 2016 Canonical Ltd.
 #
@@ -88,7 +89,7 @@
 - parameter:
     name: vmtest-add-repos
     parameters:
-        - string:
-            name: vmtest_add_repos
-            default: ""
-            description: value for CURTIN_VMTEST_ADD_REPOS
+      - string:
+          name: vmtest_add_repos
+          default: ""
+          description: value for CURTIN_VMTEST_ADD_REPOS


### PR DESCRIPTION
- Replace the `rm -rf` commands with the workspace-cleanup wrapper.
 - Use the timestamps wrapper in the longer vmtest jobs.
 - Make the vmtest builder names more uniform. The vmtest jobs now all
   begin with 'curtin-vmtest-*', while the builders are called
   vmtest-{devel,daily,proposed}.
 - Minor cosmetic changes.