### PR TITLE
On failure, archive all the things

### DIFF
--- a/cloud-init/default.yaml
+++ b/cloud-init/default.yaml
@@ -85,4 +85,3 @@
     publishers:
       - archive:
           artifacts: 'cloud-init/results/**'
-          excludes: 'cloud-init/results/*log, **/*img, **/*qcow2'

--- a/cloud-init/integration-nocloudkvm.yaml
+++ b/cloud-init/integration-nocloudkvm.yaml
@@ -103,3 +103,10 @@
             -e citest -- run "--os-name=$release" \
             --platform=nocloud-kvm --preserve-data --data-dir=results \
             --verbose "--deb=$deb"
+          rc="$?"
+          # on success remove large artifacts
+          if [ "$rc" = 0 ]; then
+            find ./results -type f \
+                -name '*.qcow2' -o -name '*.img' -o -name '*.log' -delete
+          fi
+          exit $rc

--- a/cloud-init/jobs-ci.yaml
+++ b/cloud-init/jobs-ci.yaml
@@ -285,7 +285,6 @@
             }
 
             failure {
-                archiveArtifacts artifacts: 'results/**', allowEmptyArchive: true, onlyIfSuccessful: false,
                 build job: 'admin-lp-git-autoland',
                 parameters: [string(name: 'TEST_RESULT', value: 'FAILED'),
                            string(name: 'TEST_URL', value: env.BUILD_URL),

--- a/cloud-init/jobs-ci.yaml
+++ b/cloud-init/jobs-ci.yaml
@@ -285,6 +285,7 @@
             }
 
             failure {
+                archiveArtifacts artifacts: 'results/**', allowEmptyArchive: true, onlyIfSuccessful: false,
                 build job: 'admin-lp-git-autoland',
                 parameters: [string(name: 'TEST_RESULT', value: 'FAILED'),
                            string(name: 'TEST_URL', value: env.BUILD_URL),


### PR DESCRIPTION
When we have the failure to ssh issue, it's not possible to debug this from what's currently collected.  This is an attempt to archive all of the output on failure such that we can work out why things failed. 

Local results dir for a successful run come in at 2G per dir.  So this may be too much space.  Interested in discussing other ways to capture the qcow snapshot when we fail to ssh connect.

Also, not sure if this achieves my desired goal, so looking for feedback on change independent of whether it's a good idea long term.