### PR TITLE
cloud-init integration-nocloud-kvm: retry to 'git clone' a few times

### DIFF
--- a/cloud-init/integration-nocloudkvm.yaml
+++ b/cloud-init/integration-nocloudkvm.yaml
@@ -78,12 +78,16 @@
     name: integration-nocloud-kvm
     builders:
       - shell: |
+          #!/bin/bash
+
+          retry() (for i in {{0..5}}; do sleep $((8*i**3)) && "${{@:1}}" && break; done)
+
           release="{release}"
           if [ -z "$TMPDIR" -a "$(hostname)" = "torkoal" ]; then
               export TMPDIR=/var/lib/jenkins/tmp/
           fi
           sudo rm -Rf *
-          git clone https://github.com/CanonicalLtd/server-test-scripts.git
+          retry git clone https://github.com/CanonicalLtd/server-test-scripts.git
           ./server-test-scripts/cloud-init/daily_deb.sh -v $release
           deb=$(echo "$PWD/cloud-init_"*.deb)
           if [ ! -f "$deb" ]; then
@@ -93,7 +97,7 @@
           # extract hash from cloud-init...-g[a-f][a-f]..._all.deb
           hash=$(echo "$deb" | sed 's,.*-g\([0-9a-f]\+\)-.*,\1,')
           echo "deb=$(basename $deb) hash=$hash"
-          git clone https://git.launchpad.net/cloud-init
+          retry git clone https://git.launchpad.net/cloud-init
           cd cloud-init
           git checkout --quiet "$hash"
           git log --max-count=1 --pretty=oneline HEAD


### PR DESCRIPTION
Retry the 'git clone' commands 5 times over half an hour with cubic
backoff. This should prevent temporary networking of Launchpad issues
from making the job fail.