### PR TITLE
metrics: fix the JJB braces escaping

### DIFF
--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -78,7 +78,7 @@
           #!/bin/bash
           set -e
 
-          retry() (for i in {{0..4}}; do sleep $((8*i**3)) && "${{@:1}}" && break; done)
+          retry() (for i in {0..4}; do sleep $((8*i**3)) && "${@:1}" && break; done)
 
           rm -rf *
           retry git clone https://github.com/CanonicalLtd/metrics.git


### PR DESCRIPTION
When no parameter is passed to a builder braces are not expanded: they
are literal, and should not be escaped.