### PR TITLE
Refactor the vmtest parameters and add the curtin-cloudinit-sru job

### DIFF
--- a/curtin/jobs-vmtest.yaml
+++ b/curtin/jobs-vmtest.yaml
@@ -238,3 +238,34 @@
           [ $RET -eq 2 ] && RET=0
 
           exit $RET
+
+- job:
+    name: curtin-cloudinit-sru
+    node: metal-amd64
+    parameters:
+      - landing-candidate
+      - landing-candidate-branch
+      - vmtest-add-repos:
+          default_vmtest_add_repos: "ppa:cloud-init-dev/proposed"
+      - string:
+          name: CURTIN_VMTEST_UPGRADE_PACKAGES
+          default: "cloud-init"
+      - choice:
+          name: CURTIN_VMTEST_SYSTEM_UPGRADE
+          choices:
+            - 'false'
+            - 'true'
+      - string:
+          name: vmtest_filters
+          default: "target_distro=ubuntu test_type=network"
+    properties:
+      - build-discarder:
+          num-to-keep: 5
+    wrappers:
+      - timestamps
+      - workspace-cleanup
+    builders:
+      - vmtest-devel
+    publishers:
+      - email-server-crew
+      - archive-results

--- a/curtin/jobs-vmtest.yaml
+++ b/curtin/jobs-vmtest.yaml
@@ -25,7 +25,8 @@
       - landing-candidate-branch
       - nose-args:
           default_nose_args:
-      - vmtest-add-repos
+      - vmtest-add-repos:
+          default_vmtest_add_repos:
     triggers:
       - timed: "H 0 * * *"
     builders:
@@ -52,7 +53,8 @@
       - landing-candidate-branch
       - nose-args:
           default_nose_args: tests/vmtests/test_uefi_basic.py
-      - vmtest-add-repos
+      - vmtest-add-repos:
+          default_vmtest_add_repos:
     wrappers:
       - timestamps
       - workspace-cleanup
@@ -77,7 +79,8 @@
       - landing-candidate-branch
       - nose-args:
           default_nose_args: tests/vmtests/test_basic.py
-      - vmtest-add-repos
+      - vmtest-add-repos:
+          default_vmtest_add_repos:
     builders:
       - vmtest-devel
     properties:
@@ -100,7 +103,8 @@
       - landing-candidate-branch
       - nose-args:
           default_nose_args:
-      - vmtest-add-repos
+      - vmtest-add-repos:
+          default_vmtest_add_repos:
     builders:
       - vmtest-devel
     properties:
@@ -123,7 +127,8 @@
       - landing-candidate-branch
       - nose-args:
           default_nose_args:
-      - vmtest-add-repos
+      - vmtest-add-repos:
+          default_vmtest_add_repos:
     builders:
       - vmtest-devel
     properties:
@@ -147,9 +152,8 @@
       - landing-candidate-branch
       - nose-args:
           default_nose_args:
-      - string:
-          name: vmtest_add_repos
-          default: "proposed"
+      - vmtest-add-repos:
+           default_vmtest_add_repos: "proposed"
       - string:
           name: vmtest_filters
           default: "target_distro=ubuntu"

--- a/curtin/jobs-vmtest.yaml
+++ b/curtin/jobs-vmtest.yaml
@@ -200,9 +200,6 @@
           if [ "$(hostname)" = "torkoal" ]; then
               export TMPDIR=/var/lib/jenkins/tmp/
           fi
-          if [ -n "${vmtest_add_repos}" ]; then
-              export CURTIN_VMTEST_ADD_REPOS=${vmtest_add_repos}
-          fi
 
           # construct vmtest filters
           filter_args=""

--- a/curtin/parameters.yaml
+++ b/curtin/parameters.yaml
@@ -91,5 +91,5 @@
     parameters:
       - string:
           name: CURTIN_VMTEST_ADD_REPOS
-          default: ""
+          default: '{default_vmtest_add_repos}'
           description: value for CURTIN_VMTEST_ADD_REPOS

--- a/curtin/parameters.yaml
+++ b/curtin/parameters.yaml
@@ -90,6 +90,6 @@
     name: vmtest-add-repos
     parameters:
       - string:
-          name: vmtest_add_repos
+          name: CURTIN_VMTEST_ADD_REPOS
           default: ""
           description: value for CURTIN_VMTEST_ADD_REPOS


### PR DESCRIPTION
Changes:
 - vmtest-add-repos: skip the intermediate vmtest_add_repos variable
 - Set the vmtest-add-repos parameter default from a variable
 - Add the curtin-cloudinit-sru job