### PR TITLE
curtin/cloud-init: reduce the number of stored builds

### DIFF
--- a/cloud-init/default.yaml
+++ b/cloud-init/default.yaml
@@ -68,7 +68,7 @@
       *** STOP ***
     properties:
       - build-discarder:
-          num-to-keep: 25
+          num-to-keep: 3
     publishers:
       - email-server-crew
 

--- a/curtin/default.yaml
+++ b/curtin/default.yaml
@@ -28,7 +28,7 @@
         *** STOP ***
     properties:
       - build-discarder:
-          num-to-keep: 25
+          num-to-keep: 3
     publishers:
       - email-server-crew
 

--- a/curtin/jobs-vmtest-daily.yaml
+++ b/curtin/jobs-vmtest-daily.yaml
@@ -24,9 +24,6 @@
           default_nose_args:
     triggers:
       - timed: "H 4 * * 1,3,5"
-    properties:
-      - build-discarder:
-          num-to-keep: 5
     publishers:
       - email-server-crew
       - archive-results
@@ -46,9 +43,6 @@
           default_nose_args:
     triggers:
       - timed: "H 4 * * 2,4,6"
-    properties:
-      - build-discarder:
-          num-to-keep: 5
     publishers:
       - email-server-crew
       - archive-results

--- a/curtin/jobs-vmtest-proposed.yaml
+++ b/curtin/jobs-vmtest-proposed.yaml
@@ -94,9 +94,6 @@
     name: curtin-vmtest-proposed-x
     node: torkoal
     auth-token: BUILD_ME
-    properties:
-      - build-discarder:
-          num-to-keep: 5
     publishers:
       - email-server-crew
       - archive-results
@@ -111,9 +108,6 @@
     name: curtin-vmtest-proposed-b
     node: torkoal
     auth-token: BUILD_ME
-    properties:
-      - build-discarder:
-          num-to-keep: 5
     publishers:
       - email-server-crew
       - archive-results
@@ -128,9 +122,6 @@
     name: curtin-vmtest-proposed-d
     node: torkoal
     auth-token: BUILD_ME
-    properties:
-      - build-discarder:
-          num-to-keep: 5
     publishers:
       - email-server-crew
       - archive-results
@@ -145,9 +136,6 @@
     name: curtin-vmtest-proposed-e
     node: torkoal
     auth-token: BUILD_ME
-    properties:
-      - build-discarder:
-          num-to-keep: 5
     publishers:
       - email-server-crew
       - archive-results

--- a/curtin/jobs-vmtest.yaml
+++ b/curtin/jobs-vmtest.yaml
@@ -31,9 +31,6 @@
       - timed: "H 0 * * *"
     builders:
       - vmtest-devel
-    properties:
-      - build-discarder:
-          num-to-keep: 10
     publishers:
       - archive:
           artifacts: 'output/**'
@@ -60,9 +57,6 @@
       - workspace-cleanup
     builders:
       - vmtest-devel
-    properties:
-      - build-discarder:
-          num-to-keep: 10
     publishers:
       - archive:
           artifacts: 'output/**'
@@ -83,9 +77,6 @@
           default_vmtest_add_repos:
     builders:
       - vmtest-devel
-    properties:
-      - build-discarder:
-          num-to-keep: 10
     publishers:
       - archive:
           artifacts: 'output/**'
@@ -107,9 +98,6 @@
           default_vmtest_add_repos:
     builders:
       - vmtest-devel
-    properties:
-      - build-discarder:
-          num-to-keep: 10
     publishers:
       - archive:
           artifacts: 'output/**'
@@ -131,9 +119,6 @@
           default_vmtest_add_repos:
     builders:
       - vmtest-devel
-    properties:
-      - build-discarder:
-          num-to-keep: 5
     publishers:
       - archive:
           artifacts: 'output/**'
@@ -157,9 +142,6 @@
       - string:
           name: vmtest_filters
           default: "target_distro=ubuntu"
-    properties:
-      - build-discarder:
-          num-to-keep: 5
     publishers:
       - email-server-crew
       - archive-results
@@ -258,9 +240,6 @@
       - string:
           name: vmtest_filters
           default: "target_distro=ubuntu test_type=network"
-    properties:
-      - build-discarder:
-          num-to-keep: 5
     wrappers:
       - timestamps
       - workspace-cleanup


### PR DESCRIPTION
Set the default number of stored builds to 3 and remove all the
job-specific num-to-keep settings. We'll turn the knob up for specific
jobs if needed.

Fixes #99.