### PR TITLE
COPR: switch to python3 and replace run-centos with run-container

### DIFF
--- a/cloud-init/centos.yaml
+++ b/cloud-init/centos.yaml
@@ -35,11 +35,10 @@
           git clone --single-branch https://git.launchpad.net/cloud-init
           pushd cloud-init
 
-          export PYVER=python2
           export http_proxy="http://squid.internal:3128"
           export https_proxy="$http_proxy"
 
-          retry_cmd="./tools/run-centos 7 --srpm --artifact"
+          retry_cmd="./tools/run-container centos/7 --source-package --artifacts=. --pyexe=python3"
           for i in {1..3}; do [ $i -gt 1 ] && sleep 5m; $retry_cmd && s=0 && break || s=$?; done; (exit $s)
 
           popd


### PR DESCRIPTION
The run-centos script is deprecated in favor of the more general
run-container.