### PR TITLE
cloud-init: add focal to ci

### DIFF
--- a/cloud-init/default.yaml
+++ b/cloud-init/default.yaml
@@ -23,13 +23,16 @@
       - cloud-init-github-mirror
       - cloud-init-integration-ec2-b
       - cloud-init-integration-ec2-e
+      - cloud-init-integration-ec2-f
       - cloud-init-integration-ec2-x
       - cloud-init-integration-ec2-terminate
       - cloud-init-integration-lxd-b
       - cloud-init-integration-lxd-e
+      - cloud-init-integration-lxd-f
       - cloud-init-integration-lxd-x
       - cloud-init-integration-nocloud-kvm-b
       - cloud-init-integration-nocloud-kvm-e
+      - cloud-init-integration-nocloud-kvm-f
       - cloud-init-integration-nocloud-kvm-x
       - cloud-init-integration-proposed-b-ec2
       - cloud-init-integration-proposed-b-lxd

--- a/cloud-init/integration-ec2.yaml
+++ b/cloud-init/integration-ec2.yaml
@@ -60,6 +60,21 @@
       - integration-ec2:
           release: eoan
 
+- job:
+    name: cloud-init-integration-ec2-f
+    node: torkoal
+    triggers:
+      - timed: "H 0 * * 8"
+    publishers:
+      - email-server-crew
+      - archive-results
+      - trigger:
+          project: cloud-init-integration-ec2-terminate
+          threshold: FAILURE
+    builders:
+      - integration-ec2:
+          release: focal
+
 - builder:
     name: integration-ec2
     builders:

--- a/cloud-init/integration-lxd.yaml
+++ b/cloud-init/integration-lxd.yaml
@@ -49,9 +49,22 @@
     publishers:
       - email-server-crew
       - archive-results
+      - trigger:
+          project: cloud-init-integration-lxd-f
+          threshold: FAILURE
     builders:
       - integration-lxd:
           release: eoan
+
+- job:
+    name: cloud-init-integration-lxd-f
+    node: torkoal
+    publishers:
+      - email-server-crew
+      - archive-results
+    builders:
+      - integration-lxd:
+          release: focal
 
 - builder:
     name: integration-lxd

--- a/cloud-init/integration-nocloudkvm.yaml
+++ b/cloud-init/integration-nocloudkvm.yaml
@@ -55,9 +55,24 @@
     publishers:
       - email-server-crew
       - archive-results
+      - trigger:
+          project: cloud-init-integration-nocloud-kvm-f
+          threshold: FAILURE
     builders:
       - integration-nocloud-kvm:
           release: eoan
+
+- job:
+    name: cloud-init-integration-nocloud-kvm-f
+    node: torkoal
+    parameters:
+      - boot-timeout
+    publishers:
+      - email-server-crew
+      - archive-results
+    builders:
+      - integration-nocloud-kvm:
+          release: focal
 
 - builder:
     name: integration-nocloud-kvm


### PR DESCRIPTION
Do not add '-proposed' jobs yet because we won't yet be using the -proposed suites for Focal until it officially releases