### PR TITLE
curtin: add daily vmtest-f. stripe scheduling with b and x

### DIFF
--- a/curtin/default.yaml
+++ b/curtin/default.yaml
@@ -54,6 +54,7 @@
       - curtin-vmtest-devel-s390x
       - curtin-vmtest-daily-x
       - curtin-vmtest-daily-b
+      - curtin-vmtest-daily-f
       - curtin-vmtest-proposed-b
       - curtin-vmtest-proposed-b-trigger
       - curtin-vmtest-proposed-e

--- a/curtin/jobs-vmtest-daily.yaml
+++ b/curtin/jobs-vmtest-daily.yaml
@@ -23,7 +23,7 @@
       - nose-args:
           default_nose_args:
     triggers:
-      - timed: "H 4 * * 1,3,5"
+      - timed: "H 4 * * 0,3"
     publishers:
       - email-server-crew
       - archive-results
@@ -42,7 +42,7 @@
       - nose-args:
           default_nose_args:
     triggers:
-      - timed: "H 4 * * 2,4,6"
+      - timed: "H 4 * * 1,4"
     publishers:
       - email-server-crew
       - archive-results
@@ -52,6 +52,25 @@
     builders:
       - vmtest-daily:
           release: bionic
+          nose_args: nose_args
+
+- job:
+    name: curtin-vmtest-daily-f
+    node: torkoal
+    parameters:
+      - nose-args:
+          default_nose_args:
+    triggers:
+      - timed: "H 4 * * 2,5,6"
+    publishers:
+      - email-server-crew
+      - archive-results
+    wrappers:
+      - timestamps
+      - workspace-cleanup
+    builders:
+      - vmtest-daily:
+          release: focal
           nose_args: nose_args
 
 - builder:


### PR DESCRIPTION
change daily scheduling of b and x, reducing frequency of each daily run to 1 series per day.
Alternate(stripe) across x, b and f for daily vmtest runs