### PR TITLE
copr: build using Python 3 and CentOS 8

### DIFF
--- a/cloud-init/centos.yaml
+++ b/cloud-init/centos.yaml
@@ -35,7 +35,6 @@
           git clone --single-branch https://git.launchpad.net/cloud-init
           pushd cloud-init
 
-          export PYVER=python2
           export http_proxy="http://squid.internal:3128"
           export https_proxy="$http_proxy"
 

--- a/cloud-init/centos.yaml
+++ b/cloud-init/centos.yaml
@@ -25,11 +25,12 @@
       - trigger:
           project: cloud-init-copr-test-7
           threshold: SUCCESS
+    wrappers:
+      - workspace-cleanup
     builders:
       - shell: |
           #!/bin/bash
           set -ex
-          rm -rf *
 
           git clone --depth 1 https://github.com/CanonicalLtd/server-test-scripts
           git clone --single-branch https://git.launchpad.net/cloud-init
@@ -51,11 +52,12 @@
 - job:
     name: cloud-init-copr-test-7
     node: torkoal
+    wrappers:
+      - workspace-cleanup
     builders:
       - shell: |
           #!/bin/bash
           set -e
-          rm -rf *
 
           export http_proxy="http://squid.internal:3128"
           export https_proxy="$http_proxy"

--- a/cloud-init/centos.yaml
+++ b/cloud-init/centos.yaml
@@ -38,7 +38,7 @@
           export http_proxy="http://squid.internal:3128"
           export https_proxy="$http_proxy"
 
-          retry_cmd="./tools/run-centos 7 --srpm --artifact"
+          retry_cmd="./tools/run-container centos/8 --source-package --artifacts=."
           for i in {1..3}; do [ $i -gt 1 ] && sleep 5m; $retry_cmd && s=0 && break || s=$?; done; (exit $s)
 
           popd


### PR DESCRIPTION
Changes:
 - do not export PYVER as now only Python 3 is supported
 - build the source RPM on CentOS 8
 - use the workspace-cleanup wrapper instead of 'rm -rf'