### PR TITLE
tableflip-triage-email.sh: restore Reply-To: $recipients

### DIFF
--- a/daily-triage/tableflip-triage-email.sh
+++ b/daily-triage/tableflip-triage-email.sh
@@ -168,6 +168,7 @@ subject="Daily triage for: $projects [$triager]"
     cat <<-EOF
 	From: server@jenkins.canonical.com
 	To: $recipients
+	Reply-To: $recipients
 	Subject: $subject
 	MIME-Version: 1.0
 	Content-Type: multipart/alternative; boundary="$mpboundary"


### PR DESCRIPTION
Otherwise replies go to the Jenkins email address, which can't receive
email.